### PR TITLE
Show queue in Action list (when tapping on Cover art in Playback screen, for instance)

### DIFF
--- a/res/values/untranslatable.xml
+++ b/res/values/untranslatable.xml
@@ -52,6 +52,7 @@ THE SOFTWARE.
 		<item>EnqueueArtist</item>
 		<item>EnqueueGenre</item>
 		<item>ClearQueue</item>
+		<item>ShowQueue</item>
 		<item>ToggleControls</item>
 	</string-array>
 	<string-array name="swipe_action_entries">
@@ -69,6 +70,7 @@ THE SOFTWARE.
 		<item>@string/enqueue_current_artist</item>
 		<item>@string/enqueue_current_genre</item>
 		<item>@string/clear_queue</item>
+		<item>@string/show_queue</item>
 		<item>@string/toggle_controls</item>
 	</string-array>
 	<string-array name="default_playlist_action_entries">

--- a/src/ch/blinkenlights/android/vanilla/Action.java
+++ b/src/ch/blinkenlights/android/vanilla/Action.java
@@ -81,6 +81,10 @@ enum Action {
 	 */
 	ClearQueue,
 	/**
+	 * Show the queue.
+	 */
+	ShowQueue,
+	/**
 	 * Toggle the controls in the playback activity.
 	 */
 	ToggleControls;

--- a/src/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/src/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -1912,6 +1912,11 @@ public final class PlaybackService extends Service
 			clearQueue();
 			Toast.makeText(this, R.string.queue_cleared, Toast.LENGTH_SHORT).show();
 			break;
+		case ShowQueue:
+			Intent intentShowQueue = new Intent(this, ShowQueueActivity.class);
+			intentShowQueue.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+			startActivity(intentShowQueue);
+			break;
 		case ToggleControls:
 			// Handled in FullPlaybackActivity.performAction
 			break;


### PR DESCRIPTION
User can now select "Show queue" as an action when interacting (press,
long press, swipe up, swipe down) with the Cover in the Playback Screen.

I added this because I often check the current queue (usually one or several albums from the same artist) in order to switch to a specific song, and currently I have to click on the Menu button, then select "Show queue"...
