### PR TITLE
Use FLAG_SHOW_WHEN_LOCKED as well as FLAG_DISMISS_KEYGUARD

### DIFF
--- a/src/ch/blinkenlights/android/vanilla/PlaybackActivity.java
+++ b/src/ch/blinkenlights/android/vanilla/PlaybackActivity.java
@@ -121,9 +121,11 @@ public abstract class PlaybackActivity extends Activity
 
 		Window window = getWindow();
 		if (prefs.getBoolean(PrefKeys.DISABLE_LOCKSCREEN, false))
-			window.addFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD);
+			window.addFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD
+					| WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
 		else
-			window.clearFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD);
+			window.clearFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD
+					| WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
 	}
 
 	@Override


### PR DESCRIPTION
Since I updated to Jellybean on my SGS2, the misc. option "disable lock screen" has stopped working. This option is important for people who use their phone to play music when in a car hands-free holder, because it allows you to control the music using screen swipes etc. while still concentrating on the road.

Vanilla player used to just use FLAG_DISMISS_KEYGUARD, which worked previously (possibly a bug in previous builds of Samsung GS2), but that now only works if the keyguard is not a "secure lock screen", and the API notes suggest to combine it with FLAG_SHOW_WHEN_LOCKED.

I have tested that this patch works as intended.
