### PR TITLE
Fix for NullPointerException bug

### DIFF
--- a/src/ch/blinkenlights/android/vanilla/MusicAlphabetIndexer.java
+++ b/src/ch/blinkenlights/android/vanilla/MusicAlphabetIndexer.java
@@ -124,6 +124,10 @@ public class MusicAlphabetIndexer {
 		pos = (end + start) / 2;
 		while (pos < end) {
 			cursor.moveToPosition(pos);
+			// Prevent cursor from returning null
+			if (pos == 0) {
+				break;
+			}
 			String curName   = cursor.getString(mColumnIndex);
 			String curKey    = MediaStore.Audio.keyFor(curName);
 			String curLetter = ( curKey.length() >= 3 ? curKey.substring(0, 3) : "\t~\t"); /* return fake info if there was no key */


### PR DESCRIPTION
This fixes a NullpointerException bug that android 4.4.2 update introduced in my Samsung Galaxy S4. For whatever reason the cursor content is null at index 0. That's why we should break at that point and let the method return 0. This causes the fastScroller to show (before A) the first letter in the ALPHABET string array which is " ". 
