### PR TITLE
about: use HTML entities rather than literal UTF-8

### DIFF
--- a/assets/about.html
+++ b/assets/about.html
@@ -34,8 +34,8 @@ function show(n) {
 	<li>Mildred Ki'Lya (stop after track mode)</li>
 	<li>Jerry Liao (Chinese (Taiwan) translation)</li>
 	<li>Rosario Antoci (Italian translation)</li>
-	<li>Emir Sarı (Turkish translation)</li>
-	<li>Jiri Grönroos (Finnish translation)</li>
+	<li>Emir Sar&#305; (Turkish translation)</li>
+	<li>Jiri Gr&ouml;nroos (Finnish translation)</li>
 	<!-- TODO: add more translators -->
 </ul>
 <h2>Licenses</h2>


### PR DESCRIPTION
The page is interpreted as Latin-1 by default and they show up as
mojibake.

---

Fixes #109.
