### PR TITLE
Fixed: continue playing next song if an error happens during the current one.

### DIFF
--- a/src/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/src/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -1260,7 +1260,7 @@ public final class PlaybackService extends Service
 	public boolean onError(MediaPlayer player, int what, int extra)
 	{
 		Log.e("VanillaMusic", "MediaPlayer error: " + what + ' ' + extra);
-		return true;
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
There seem to be some files that (at least on my phone with Android 4.4) always
generate an error what=1 and extra=-1004, and more often if you seek within
the song.I consider this a bug in MediaPlayer, but nonetheless, we should just
move on to the next song instead of hanging to the current one.