### PR TITLE
add "Empty queue" option in Queue activity

### DIFF
--- a/res/values/translatable.xml
+++ b/res/values/translatable.xml
@@ -266,6 +266,7 @@ THE SOFTWARE.
 	<string name="enqueue_current_artist">Enqueue artist</string>
 	<string name="enqueue_current_genre">Enqueue genre</string>
 	<string name="clear_queue">Clear queue</string>
+	<string name="empty_the_queue">Empty queue</string>
 	<string name="show_queue">Show queue</string>
 	<string name="queue">Queue</string>
 	<string name="toggle_controls">Toggle controls</string>

--- a/src/ch/blinkenlights/android/vanilla/PlaybackActivity.java
+++ b/src/ch/blinkenlights/android/vanilla/PlaybackActivity.java
@@ -349,6 +349,7 @@ public abstract class PlaybackActivity extends Activity
 	static final int MENU_SHOW_QUEUE = 13;
 	static final int MENU_SAVE_AS_PLAYLIST = 14;
 	static final int MENU_DELETE = 15;
+	static final int MENU_EMPTY_QUEUE = 16;
 
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu)

--- a/src/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/src/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -1642,6 +1642,8 @@ public final class PlaybackService extends Service
 	 */
 	public void emptyQueue()
 	{
+		pause();
+		setFlag(FLAG_EMPTY_QUEUE);
 		mTimeline.emptyQueue();
 	}
 

--- a/src/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/src/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -1638,6 +1638,14 @@ public final class PlaybackService extends Service
 	}
 
 	/**
+	 * Empty the song queue.
+	 */
+	public void emptyQueue()
+	{
+		mTimeline.emptyQueue();
+	}
+
+	/**
 	 * Return the error message set when FLAG_ERROR is set.
 	 */
 	public String getErrorMessage()

--- a/src/ch/blinkenlights/android/vanilla/ShowQueueActivity.java
+++ b/src/ch/blinkenlights/android/vanilla/ShowQueueActivity.java
@@ -73,6 +73,7 @@ public class ShowQueueActivity extends PlaybackActivity
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {
 		menu.add(0, MENU_CLEAR_QUEUE, 0, R.string.clear_queue).setIcon(R.drawable.ic_menu_close_clear_cancel);
+		menu.add(0, MENU_EMPTY_QUEUE, 0, R.string.empty_the_queue);
 		menu.add(0, MENU_SAVE_AS_PLAYLIST, 0, R.string.save_as_playlist).setIcon(R.drawable.ic_menu_preferences);
 		return true;
 	}
@@ -92,6 +93,9 @@ public class ShowQueueActivity extends PlaybackActivity
 				NewPlaylistDialog dialog = new NewPlaylistDialog(this, null, R.string.create, null);
 				dialog.setOnDismissListener(this);
 				dialog.show();
+				break;
+			case MENU_EMPTY_QUEUE:
+				PlaybackService.get(this).emptyQueue();
 				break;
 			default:
 				return super.onOptionsItemSelected(item);

--- a/src/ch/blinkenlights/android/vanilla/SongTimeline.java
+++ b/src/ch/blinkenlights/android/vanilla/SongTimeline.java
@@ -787,6 +787,23 @@ public final class SongTimeline {
 	}
 
 	/**
+	 * Empty the song queue (clear the whole queue).
+	 */
+	public void emptyQueue()
+	{
+		synchronized (this) {
+			mSongs.clear();
+		}
+
+		if (mCallback != null) {
+			mCallback.activeSongReplaced(+1, getSong(+1));
+			mCallback.positionInfoChanged();
+		}
+
+		changed();
+	}
+
+	/**
 	 * Save the active songs for use with broadcastChangedSongs().
 	 *
 	 * @see SongTimeline#broadcastChangedSongs()

--- a/src/ch/blinkenlights/android/vanilla/SongTimeline.java
+++ b/src/ch/blinkenlights/android/vanilla/SongTimeline.java
@@ -774,15 +774,12 @@ public final class SongTimeline {
 	public void clearQueue()
 	{
 		synchronized (this) {
+			saveActiveSongs();
 			if (mCurrentPos + 1 < mSongs.size())
 				mSongs.subList(mCurrentPos + 1, mSongs.size()).clear();
 		}
 
-		if (mCallback != null) {
-			mCallback.activeSongReplaced(+1, getSong(+1));
-			mCallback.positionInfoChanged();
-		}
-
+		broadcastChangedSongs();
 		changed();
 	}
 
@@ -792,14 +789,11 @@ public final class SongTimeline {
 	public void emptyQueue()
 	{
 		synchronized (this) {
+			saveActiveSongs();
 			mSongs.clear();
 		}
 
-		if (mCallback != null) {
-			mCallback.activeSongReplaced(+1, getSong(+1));
-			mCallback.positionInfoChanged();
-		}
-
+		broadcastChangedSongs();
 		changed();
 	}
 


### PR DESCRIPTION
TODO @adrian-bl :

- `empty_queue` string already exists (should be renamed probably)
- `clear_queue` should be renamed to `dequeue_rest` and changed to "Dequeue rest"