### PR TITLE
Fix parsing of long frame lengths

### DIFF
--- a/src/ch/blinkenlights/bastp/ID3v2File.java
+++ b/src/ch/blinkenlights/bastp/ID3v2File.java
@@ -75,7 +75,7 @@ public class ID3v2File extends Common {
 		HashMap tags = new HashMap();
 		byte[] frame   = new byte[10]; // a frame header is always 10 bytes
 		long bread     = 0;            // total amount of read bytes
-		
+
 		while(bread < payload_len) {
 			bread += s.read(frame);
 			String framename = new String(frame, 0, 4);
@@ -83,7 +83,8 @@ public class ID3v2File extends Common {
 			slen = unsyncsafe(slen);
 			
 			/* Abort on silly sizes */
-			if(slen < 1 || slen > 524288)
+			long bytesRemaining = payload_len - bread;
+			if(slen < 1 || slen > (bytesRemaining))
 				break;
 			
 			byte[] xpl = new byte[slen];

--- a/src/ch/blinkenlights/bastp/ID3v2File.java
+++ b/src/ch/blinkenlights/bastp/ID3v2File.java
@@ -80,7 +80,7 @@ public class ID3v2File extends Common {
 			bread += s.read(frame);
 			String framename = new String(frame, 0, 4);
 			int slen = b2be32(frame, 4);
-            slen = unsyncsafe(slen);
+			slen = unsyncsafe(slen);
 			
 			/* Abort on silly sizes */
 			if(slen < 1 || slen > 524288)


### PR DESCRIPTION
As per http://id3.org/id3v2.4.0-structure section 4, the frame size field is a syncsafe integer, and reading without first converting is incorrect.

I have an MP3 file to demonstrate that the current behavior is incorrect and that my patch fixes it, but I'm not sure where to upload it (also, this is my first pull request, so let me know if I did something wrong).