### PR TITLE
Small translation improvements

### DIFF
--- a/res/values/translatable.xml
+++ b/res/values/translatable.xml
@@ -284,6 +284,11 @@ THE SOFTWARE.
 	<string name="toggle_controls">Toggle controls</string>
 	<string name="seek_10s_backward">Seek 10 seconds backward</string>
 	<string name="seek_10s_forward">Seek 10 seconds forward</string>
+	<string name="list_show_queue">Show queue</string>
+	<string name="list_clear_queue">Clear queue</string>
+	<string name="list_enqueue_current_album">Enqueue album</string>
+	<string name="list_enqueue_current_artist">Enqueue artist</string>
+	<string name="list_enqueue_current_genre">Enqueue genre</string>
 
 	<string name="filebrowser_start">Filebrowser home</string>
 	<string name="customize_filebrowser_start">Filebrowser starts at this directory</string>

--- a/res/values/untranslatable.xml
+++ b/res/values/untranslatable.xml
@@ -82,7 +82,7 @@ THE SOFTWARE.
 		<item>@string/last_used_action</item>
 		<item>@string/play_all</item>
 		<item>@string/enqueue_all</item>
-		<item>@string/do_nothing</item>
+		<item>@string/none</item>
 	</string-array>
 	<string-array name="default_action_entries">
 		<item>@string/play</item>
@@ -90,7 +90,7 @@ THE SOFTWARE.
 		<item>@string/last_used_action</item>
 		<item>@string/play_all</item>
 		<item>@string/enqueue_all</item>
-		<item>@string/do_nothing</item>
+		<item>@string/none</item>
 		<item>@string/expand</item>
 		<item>@string/play_or_enqueue</item>
 		<item>@string/enqueue_as_next</item>

--- a/res/values/untranslatable.xml
+++ b/res/values/untranslatable.xml
@@ -67,11 +67,11 @@ THE SOFTWARE.
 		<item>@string/previous_album</item>
 		<item>@string/cycle_repeat_mode</item>
 		<item>@string/cycle_shuffle_mode</item>
-		<item>@string/enqueue_current_album</item>
-		<item>@string/enqueue_current_artist</item>
-		<item>@string/enqueue_current_genre</item>
-		<item>@string/clear_queue</item>
-		<item>@string/show_queue</item>
+		<item>@string/list_enqueue_current_album</item>
+		<item>@string/list_enqueue_current_artist</item>
+		<item>@string/list_enqueue_current_genre</item>
+		<item>@string/list_clear_queue</item>
+		<item>@string/list_show_queue</item>
 		<item>@string/toggle_controls</item>
 		<item>@string/seek_10s_forward</item>
 		<item>@string/seek_10s_backward</item>


### PR DESCRIPTION
 * Added few more strings to improve context handling of swap option list for some languages (Serbian, for example)
 * Use 'None' instead of 'Do nothing' ("Default action" implies name of an action, not what to do). Fits better and also may improve context for some languages