### PR TITLE
Moved preamp recommendation note to dialog. 

### DIFF
--- a/res/layout/shake_pref.xml
+++ b/res/layout/shake_pref.xml
@@ -35,4 +35,12 @@ THE SOFTWARE.
 		android:padding="15dip"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content" />
+	<TextView
+		android:id="@+id/message"
+		android:paddingBottom="15dip"
+		android:paddingLeft="24dip"
+		android:paddingRight="24dip"
+		android:layout_height="wrap_content"
+		android:layout_width="fill_parent"
+		android:visibility="gone"/>
 </LinearLayout>

--- a/res/values/translatable.xml
+++ b/res/values/translatable.xml
@@ -171,6 +171,7 @@ THE SOFTWARE.
 	<string name="replaygain_bump_title">Replay Gain Pre-amp</string>
 	<string name="replaygain_untagged_debump_title">Songs without Replay Gain tag</string>
 	<string name="replaygain_untagged_debump_summary">Decrease volume by</string>
+	<string name="replaygain_preamp_note_content">Note: Android does not allow Vanilla Music to raise the volume to >100%. Setting the Pre-amp to a high value may cause issues if you are listening to \'quiet\' music. \n\nRecommended values are:\n-> -3dB for silent/classical music\n-> +3dB for post-2000 recordings</string>
 
 	<string name="readahead">Enable readahead</string>
 	<string name="readahead_summary">Readahead the currently playing song. This option may solve \'audio dropout\' issues. (caused by a slow SD card)</string>

--- a/res/xml/preference_replaygain.xml
+++ b/res/xml/preference_replaygain.xml
@@ -38,6 +38,7 @@ THE SOFTWARE.
 		android:negativeButtonText="@null"
 		android:dialogLayout="@layout/shake_pref"
 		android:title="@string/replaygain_bump_title"
+		android:dialogMessage="@string/replaygain_preamp_note_content"
 		android:defaultValue="75" />
 	<ch.blinkenlights.android.vanilla.SeekBarPreference
 		android:key="replaygain_untagged_debump"
@@ -45,13 +46,4 @@ THE SOFTWARE.
 		android:dialogLayout="@layout/shake_pref"
 		android:title="@string/replaygain_untagged_debump_title"
 		android:defaultValue="150" />
-		
-	<EditTextPreference
-		android:enabled="false"
-		android:title="Note"
-		android:summary="Android does not allow Vanilla Music to raise the volume 
-to >100%. Setting the Pre-amp to a high value may cause issues if you are listening to 'quiet' music.
-\nRecommended values are:\n-> -3dB for silent/classical music\n-> +3dB for post-2000 recordings"
-		/>
-		
 </PreferenceScreen>

--- a/src/ch/blinkenlights/android/vanilla/SeekBarPreference.java
+++ b/src/ch/blinkenlights/android/vanilla/SeekBarPreference.java
@@ -25,6 +25,7 @@ package ch.blinkenlights.android.vanilla;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.preference.DialogPreference;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.SeekBar;
@@ -100,6 +101,13 @@ public class SeekBarPreference extends DialogPreference implements SeekBar.OnSee
 
 		mValueText = (TextView)view.findViewById(R.id.value);
 		mValueText.setText(getSummary(mValue));
+
+		CharSequence dialogMessage = getDialogMessage();
+		if(!TextUtils.isEmpty(dialogMessage)) {
+			TextView messageTextView = (TextView) view.findViewById(R.id.message);
+			messageTextView.setText(dialogMessage);
+			messageTextView.setVisibility(View.VISIBLE);
+		}
 
 		SeekBar seekBar = (SeekBar)view.findViewById(R.id.seek_bar);
 


### PR DESCRIPTION
This is a solution for the preamp note not being visible and not being translatable (#198).

I made two minor changes to the message itself:
* Moved the 'Note' title inline, as it no longer has a title
* Added a blank line before the recommendations to avoid the wall-of-text look

Unrelated to the changes, I think the paddings look a bit strange. In particular that the components don't align to the title/button, which are 24dp horizontally padded. The [material spec](http://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-baseline-grids) gives an 8dp grid for components and 4dp grid for typeface. What are your thoughts on adjusting the layouts of the dialogs to fit this? 