### PR TITLE
DragSortController: Check for null MotionEvent arguments (#202)

### DIFF
--- a/src/com/mobeta/android/dslv/DragSortController.java
+++ b/src/com/mobeta/android/dslv/DragSortController.java
@@ -378,6 +378,11 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
     @Override
     public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
 
+        // Guard against rare case of null MotionEvents on some devices
+        if (e1 == null || e2 == null) {
+            return false;
+        }
+
         final int x1 = (int) e1.getX();
         final int y1 = (int) e1.getY();
         final int x2 = (int) e2.getX();


### PR DESCRIPTION
This fixes a rare crash on Samsung Galaxy S6 devices. The null arguments
appear to be caused by the GestureDetector not receiving an ACTION_DOWN
event before receiving an ACTION_MOVE event.

As we are unable to reproduce it, this commit work around the issue. It
might cause some scrolling issues in the cases that cause the issue, but
better than crashing.