### PR TITLE
Revert "Attempt to fix #113"

### DIFF
--- a/src/com/mobeta/android/dslv/DragSortController.java
+++ b/src/com/mobeta/android/dslv/DragSortController.java
@@ -236,11 +236,11 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
 
     @Override
     public boolean onTouch(View v, MotionEvent ev) {
-        mDetector.onTouchEvent(ev);
         if (!mDslv.isDragEnabled() || mDslv.listViewIntercepted()) {
             return false;
         }
 
+        mDetector.onTouchEvent(ev);
         if (mRemoveEnabled && mDragging && mRemoveMode == FLING_REMOVE) {
             mFlingRemoveDetector.onTouchEvent(ev);
         }


### PR DESCRIPTION
This reverts commit 7835436a3553f36e6457f8900ac9a5763b2bfbec.

Commit 7835436a attempted to fix the rare DSLV crash described in #113
by passing all touch events to the gesture detector. This includes
touches that occur when the drag is disabled or the list view wants to
intercept the event, and so is marginally undesirable. Also a factor is
that the DSLV code is taken from a third-party project, and so should be
kept as consistent as possible with upstream.

The attempt appears to not have worked, so a more direct workaround was
implemented in commit 4556d50ed, making 7835436a redundant. This commit
reverts 7835436a.