### PR TITLE
Check width and height > 0 before generating bitmap

### DIFF
--- a/src/ch/blinkenlights/android/vanilla/CoverView.java
+++ b/src/ch/blinkenlights/android/vanilla/CoverView.java
@@ -359,6 +359,12 @@ public final class CoverView extends View implements Handler.Callback {
 	 */
 	private void generateBitmap(int i)
 	{
+		if(getWidth() == 0 || getHeight() == 0) {
+			// View isn't laid out - can't generate the bitmap until we know the size
+			mPendingQuery = true;
+			return;
+		}
+
 		Song song = mSongs[i];
 
 		int style = mCoverStyle;


### PR DESCRIPTION
Creating a bitmap with 0 width or height will cause a fatal exception.

A check was added in commit 2149745, but there are still some crashes
(e.g. issue #267). This commit replicates that check directly before the
creation of the bitmap.