### PR TITLE
Exclude empty genres from genre list

### DIFF
--- a/src/ch/blinkenlights/android/vanilla/MediaAdapter.java
+++ b/src/ch/blinkenlights/android/vanilla/MediaAdapter.java
@@ -344,7 +344,10 @@ public class MediaAdapter
 		}
 
 		QueryTask query;
-		if (limiter != null && limiter.type == MediaUtils.TYPE_GENRE) {
+		if(mType == MediaUtils.TYPE_GENRE && !returnSongs) {
+			query = MediaUtils.buildGenreExcludeEmptyQuery(projection, selection.toString(),
+					selectionArgs, sort);
+		} else if (limiter != null && limiter.type == MediaUtils.TYPE_GENRE) {
 			// Genre is not standard metadata for MediaStore.Audio.Media.
 			// We have to query it through a separate provider. : /
 			query = MediaUtils.buildGenreQuery((Long)limiter.data, projection,  selection.toString(), selectionArgs, sort, mType, returnSongs);


### PR DESCRIPTION
Previously, genres without any songs associated with them would appear
in the Library genre list.

This commit adds a new query for genres that excludes these empty genres.

This partially fixes issue #286 (empty genres cannot be deleted) -
genres still can't be deleted, but the empty ones will no longer appear.