### PR TITLE
Implement lyrics fetching using open LyricsWiki API

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -30,6 +30,7 @@ THE SOFTWARE.
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+	<uses-permission android:name="android.permission.INTERNET" />
 	<!-- This is needed for isWiredHeadsetOn() to work in some cases. (bug?) -->
 	<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 	<application

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
     }
 }
 
@@ -44,4 +44,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
+}
+
+dependencies {
+    compile 'org.jsoup:jsoup:1.8.3'     // for parsing lyrics wiki pages
 }

--- a/res/layout/lyrics_dialog.xml
+++ b/res/layout/lyrics_dialog.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/* //device/apps/common/res/layout/alert_dialog.xml
+**
+** Copyright 2006, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="match_parent"
+             android:layout_height="wrap_content">
+
+    <LinearLayout android:id="@+id/body"
+                  android:orientation="horizontal"
+                  android:layout_width="match_parent"
+                  android:layout_height="match_parent"
+                  android:baselineAligned="false"
+                  android:paddingStart="8dip"
+                  android:paddingTop="10dip"
+                  android:paddingEnd="8dip"
+                  android:paddingBottom="10dip">
+
+        <ProgressBar android:id="@android:id/progress"
+                     style="?android:attr/progressBarStyle"
+                     android:layout_width="wrap_content"
+                     android:layout_height="wrap_content"
+                     android:indeterminate="true"
+                     android:layout_marginEnd="12dip" />
+
+        <TextView android:id="@+id/message"
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:layout_gravity="center_vertical" />
+    </LinearLayout>
+</FrameLayout>

--- a/res/values-ru/translatable.xml
+++ b/res/values-ru/translatable.xml
@@ -225,4 +225,9 @@
   <string name="filebrowser_start">Домашняя папка браузера файлов</string>
   <string name="customize_filebrowser_start">Браузер файлов открывает эту папку</string>
   <string name="select">Выбрать</string>
+  <string name="get_lyrics">Скачать текст</string>
+  <string name="fetching_lyrics">Поиск текста</string>
+  <string name="lyrics_not_found">Текст песни не найден</string>
+  <string name="please_wait">Пожалуйста, подождите…</string>
+  <string name="song_lyrics">Текст песни</string>
 </resources>

--- a/res/values/translatable.xml
+++ b/res/values/translatable.xml
@@ -319,4 +319,9 @@ THE SOFTWARE.
 
 	<string name="permission_request_summary">Vanilla Music needs read permission to display your music library</string>
 	<string name="ok">Ok</string>
+	<string name="get_lyrics">Fetch lyrics</string>
+	<string name="fetching_lyrics">Fetching lyrics</string>
+	<string name="lyrics_not_found">Lyrics not found</string>
+	<string name="please_wait">Please wait…</string>
+	<string name="song_lyrics">Song lyrics</string>
 </resources>

--- a/src/ch/blinkenlights/android/vanilla/LibraryActivity.java
+++ b/src/ch/blinkenlights/android/vanilla/LibraryActivity.java
@@ -66,6 +66,8 @@ import android.widget.SearchView;
 import java.io.File;
 import junit.framework.Assert;
 
+import ch.blinkenlights.android.vanilla.lyrics.LyricsDialog;
+
 /**
  * The library activity where songs to play can be selected from the library.
  */
@@ -625,6 +627,7 @@ public class LibraryActivity
 	private static final int MENU_MORE_FROM_ALBUM = 11;
 	private static final int MENU_MORE_FROM_ARTIST = 12;
 	private static final int MENU_OPEN_EXTERNAL = 13;
+	private static final int MENU_GET_LYRICS = 14;
 
 	/**
 	 * Creates a context menu for an adapter row.
@@ -660,6 +663,7 @@ public class LibraryActivity
 				menu.add(0, MENU_MORE_FROM_ALBUM, 0, R.string.more_from_album).setIntent(rowData);
 			menu.addSubMenu(0, MENU_ADD_TO_PLAYLIST, 0, R.string.add_to_playlist).getItem().setIntent(rowData);
 			menu.add(0, MENU_DELETE, 0, R.string.delete).setIntent(rowData);
+			menu.add(0, MENU_GET_LYRICS, 0, R.string.get_lyrics).setIntent(rowData);
 		}
 	}
 
@@ -782,6 +786,16 @@ public class LibraryActivity
 		case MENU_MORE_FROM_ALBUM:
 			setLimiter(MediaUtils.TYPE_ALBUM, "_id=" + intent.getLongExtra(LibraryAdapter.DATA_ID, LibraryAdapter.INVALID_ID));
 			updateLimiterViews();
+			break;
+		case MENU_GET_LYRICS:
+			long id = intent.getLongExtra(LibraryAdapter.DATA_ID, LibraryAdapter.INVALID_ID);
+			Song queried = MediaUtils.getSongByTypeId(getContentResolver(), MediaUtils.TYPE_SONG, id);
+			if(queried == null) {
+				break;
+			}
+			
+			LyricsDialog lrd = LyricsDialog.newInstance(queried.artist, queried.title);
+			lrd.show(getFragmentManager(), "LyricsDialog");
 			break;
 		}
 

--- a/src/ch/blinkenlights/android/vanilla/lyrics/LyricsDialog.java
+++ b/src/ch/blinkenlights/android/vanilla/lyrics/LyricsDialog.java
@@ -1,0 +1,125 @@
+package ch.blinkenlights.android.vanilla.lyrics;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.app.ProgressDialog;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.Message;
+import android.text.TextUtils;
+import android.text.method.ScrollingMovementMethod;
+import android.util.TypedValue;
+import android.view.View;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import org.w3c.dom.Text;
+
+import ch.blinkenlights.android.vanilla.R;
+
+/**
+ * Dialog to show fetched lyrics
+ */
+public class LyricsDialog extends DialogFragment {
+    
+    private static final String ARTIST = "artist_key"; 
+    private static final String TITLE = "title_key"; 
+
+    private Handler mHandler;
+    private LyricsEngine mLyricsEngine = new LyricsWikiEngine();
+    
+    private ProgressBar mProgressBar;
+    private TextView mLyricsText;
+    
+    public static LyricsDialog newInstance(String artist, String title) {
+        Bundle args = new Bundle(2);
+        args.putString(ARTIST, artist);
+        args.putString(TITLE, title);
+        
+        LyricsDialog lrd = new LyricsDialog();
+        lrd.setArguments(args);
+        return lrd;
+    }
+    
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        
+        HandlerThread thread = new HandlerThread("LyricsFetcher");
+        thread.start();
+        mHandler = new Handler(thread.getLooper(), new LyricsHandler());
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        
+        mHandler.getLooper().quit();
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        // there's no way to retrieve underlying dialog views, hence we need to use
+        // our own inflated layout in order to gain complete control
+        View progressDialog = View.inflate(getActivity(), R.layout.lyrics_dialog, null);
+        mProgressBar = (ProgressBar) progressDialog.findViewById(android.R.id.progress);
+        mLyricsText = (TextView) progressDialog.findViewById(R.id.message);
+
+        // setup simple waiting view
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.fetching_lyrics);
+        mLyricsText.setText(R.string.please_wait);
+        builder.setView(progressDialog);
+        
+        return builder.create();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        
+        mHandler.sendEmptyMessage(0);
+    }
+
+    private class LyricsHandler implements Handler.Callback {
+        
+        @Override
+        public boolean handleMessage(Message msg) {
+            // the only message that is requested is song lyrics fetch
+            Bundle args = getArguments(); // provided on creating
+            String lyrics = mLyricsEngine.getLyrics(args.getString(ARTIST), args.getString(TITLE));
+            getActivity().runOnUiThread(new ResponseAction(lyrics));
+            
+            return true;
+        }
+    }
+    
+    private class ResponseAction implements Runnable {
+
+        private final String lyrics;
+        
+        public ResponseAction(String lyrics) {
+            this.lyrics = lyrics;
+        }
+
+        @Override
+        public void run() {
+            if(TextUtils.isEmpty(lyrics)) {
+                // no lyrics - show excuse
+                dismiss();
+                Toast.makeText(getActivity(), R.string.lyrics_not_found, Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            AlertDialog dialog = (AlertDialog) getDialog();
+            dialog.setTitle(R.string.song_lyrics);
+            mProgressBar.setVisibility(View.GONE);
+            mLyricsText.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
+            mLyricsText.setMovementMethod(new ScrollingMovementMethod());
+            mLyricsText.setText(lyrics);
+        }
+    }
+}

--- a/src/ch/blinkenlights/android/vanilla/lyrics/LyricsEngine.java
+++ b/src/ch/blinkenlights/android/vanilla/lyrics/LyricsEngine.java
@@ -1,0 +1,22 @@
+package ch.blinkenlights.android.vanilla.lyrics;
+
+import android.content.Loader;
+import android.os.HandlerThread;
+
+/**
+ * Interface for various engines for lyrics extraction
+ * 
+ * @author Oleg Chernovskiy
+ */
+public interface LyricsEngine {
+
+    /**
+     * Synchronous call to engine to retrieve lyrics. Most likely to be used in {@link HandlerThread}
+     * or {@link Loader}
+     * @param artistName band or artist name to search for
+     * @param songTitle full song title to search for
+     * @return string containing song lyrics if available, null if nothing found
+     */
+    String getLyrics(String artistName, String songTitle);
+    
+}

--- a/src/ch/blinkenlights/android/vanilla/lyrics/LyricsWikiEngine.java
+++ b/src/ch/blinkenlights/android/vanilla/lyrics/LyricsWikiEngine.java
@@ -1,0 +1,157 @@
+package ch.blinkenlights.android.vanilla.lyrics;
+
+import android.net.Uri;
+import android.text.TextUtils;
+import android.util.Log;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.net.URL;
+
+import javax.net.ssl.HttpsURLConnection;
+
+/**
+ * Implementation of lyrics engine based on LyricsWiki API.
+ * This api, although hard to find, provides <code>getSong</code> API call
+ * to find the corresponding song by artist and title.
+ * 
+ * <p/> The licensing issues don't allow it to return full song lyrics on API call.
+ * Hence the retrieval is done in 2 steps - first, call to <code>getSong</code> to 
+ * find the requested song and, if found, get the page containing full song lyrics
+ * 
+ * @author Oleg Chernovskiy
+ * 
+ */
+public class LyricsWikiEngine implements LyricsEngine {
+
+    private static final String TAG = LyricsWikiEngine.class.getSimpleName();
+    
+    @Override
+    public String getLyrics(String artistName, String songTitle) {
+        try {
+            
+            String lyricsUrl = makeApiCall(artistName, songTitle);
+            if (lyricsUrl == null) { // no URL in API answer or no correct answer at all
+                return null;
+            }
+
+            return parseFullLyricsPage(lyricsUrl);
+
+        } catch (IOException e) {
+            Log.w(TAG, "Couldn't connect to lyrics wiki REST endpoints", e);
+            return null;
+        } catch (JSONException e) {
+            Log.w(TAG, "Couldn't transform API answer to JSON entity", e);
+            return null;
+        }
+    }
+
+    /**
+     * First call
+     */
+    private String makeApiCall(String artistName, String songTitle) throws IOException, JSONException {
+        HttpsURLConnection apiCall = null;
+        try {
+            // build query
+            // e.g. https://lyrics.wikia.com/api.php?func=getSong&artist=The%20Beatle&song=Girl&fmt=realjson
+            Uri link = new Uri.Builder()
+                    .scheme("https")
+                    .authority("lyrics.wikia.com")
+                    .path("api.php")
+                    .appendQueryParameter("func", "getSong")
+                    .appendQueryParameter("fmt", "realjson")
+                    .appendQueryParameter("artist", artistName)
+                    .appendQueryParameter("song", songTitle)
+                    .build();
+
+            // construct an http request
+            apiCall = (HttpsURLConnection) new URL(link.toString()).openConnection();
+            apiCall.setReadTimeout(10_000);
+            apiCall.setConnectTimeout(15_000);
+
+            // execute
+            apiCall.connect();
+            int response = apiCall.getResponseCode();
+            if (response != HttpsURLConnection.HTTP_OK) {
+                // redirects are handled internally, this is clearly an error
+                return null;
+            }
+
+            InputStream is = apiCall.getInputStream();
+            String reply = readIt(is);
+            JSONObject getSongAnswer = new JSONObject(reply);
+
+            return getLyricsUrl(getSongAnswer);
+        } finally {
+            if(apiCall != null) {
+                apiCall.disconnect();
+            }
+        }
+    }
+
+    /**
+     * Second call
+     */
+    private String parseFullLyricsPage(String lyricsUrl) throws IOException {
+        Document page = Jsoup.parse(new URL(lyricsUrl), 10_000);
+        Element lyricsBox = page.select("div.lyricbox").first();
+        if(lyricsBox == null) { // no lyrics frame on page
+            return null;
+        }
+
+        // remove unneeded elements
+        lyricsBox.select("div.rtMatcher").remove();
+        lyricsBox.select("div.lyricsbreak").remove();
+        lyricsBox.select("script").remove();
+        
+        StringBuilder builder = new StringBuilder();
+        for(Node curr : lyricsBox.childNodes()) {
+            if(curr instanceof TextNode) {
+                builder.append(((TextNode) curr).text());
+            } else {
+                builder.append("\n");
+            }
+        }
+
+        return builder.toString();
+    }
+    
+    private String getLyricsUrl(JSONObject getSongAnswer) {
+        try {
+            String pageId = getSongAnswer.getString("page_id");
+            if(TextUtils.isEmpty(pageId)) {
+                return null; // empty page_id means page wasn't created
+            }
+            return getSongAnswer.getString("url");
+        } catch (JSONException e) {
+            Log.w(TAG, "Unknown format of getSong API call answer", e);
+            return null;
+        }
+    }
+    
+    // Reads an InputStream and converts it to a String.
+    public String readIt(InputStream stream) throws IOException {
+        Reader reader = new InputStreamReader(stream, "UTF-8");
+        StringWriter sw = new StringWriter();
+        char[] buffer = new char[4096];
+        int count;
+        while ((count = reader.read(buffer)) != -1) {
+            sw.write(buffer, 0, count);
+        }
+        
+        return sw.toString();
+    }
+    
+}


### PR DESCRIPTION
This PR adds new action for song list context menu

It creates a background activity to fetch lyrics page from LyricsWiki
and shows lyrics text of the song in the dialog

Future plans: 
- saving of lyrics to `USLT` tag (and retrieval)
- support for lyrics synchronization from `*.lrc` files