### PR TITLE
MirrorLink: allow RockScout remote access outside of a Car

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -36,6 +36,10 @@ THE SOFTWARE.
 		android:icon="@drawable/icon"
 		android:label="@string/app_name">
 
+		<meta-data
+		android:name="com.mirrorlink.android.rockscout.allow-offline-access"
+		android:value="true" />
+
 		<activity
 			android:name="FullPlaybackActivity"
 			android:launchMode="singleTask" />


### PR DESCRIPTION
Hi Adrian,

Long time no see, Vanilla is becoming increasingly popular within the MirrorLink community to listen to local media whilst in their car, using RockScout (http://www.mirrorlink.com/apps/Vanilla%20Music%20with%20RockScout).

We have now an option to enable RockScout to be used as a front-end out of the car, if the media source allows for it.

Here's the patch that indicates Vanilla's willingness to fully participate in the RockScout experience, let me know if you have any concerns with it.

Best regards,
Laurent