### PR TITLE
Add path to extended currently playing view

### DIFF
--- a/res/layout/full_playback_alt.xml
+++ b/res/layout/full_playback_alt.xml
@@ -103,6 +103,14 @@ THE SOFTWARE.
 		</TableRow>
 		<TableRow>
 			<TextView
+				android:text="@string/_path"
+				android:textColor="?overlay_foreground_color"
+				android:paddingRight="5dip"
+				android:gravity="right" />
+			<TextView android:id="@+id/path" android:textColor="?overlay_foreground_color"/>
+		</TableRow>
+		<TableRow>
+			<TextView
 				android:text="@string/_format"
 				android:textColor="?overlay_foreground_color"
 				android:paddingRight="5dip"

--- a/res/values/translatable.xml
+++ b/res/values/translatable.xml
@@ -44,6 +44,7 @@ THE SOFTWARE.
 	<string name="_genre">genre</string>
 	<string name="_track">track</string>
 	<string name="_composer">composer</string>
+	<string name="_path">path</string>
 	<string name="_format">format</string>
 	<string name="_title">title</string>
 	<string name="_artist">artist</string>

--- a/src/ch/blinkenlights/android/vanilla/FullPlaybackActivity.java
+++ b/src/ch/blinkenlights/android/vanilla/FullPlaybackActivity.java
@@ -100,6 +100,8 @@ public class FullPlaybackActivity extends SlidingPlaybackActivity
 	private TextView mYearView;
 	private String mComposer;
 	private TextView mComposerView;
+	private String mPath;
+	private TextView mPathView;
 	private String mFormat;
 	private TextView mFormatView;
 	private String mReplayGain;
@@ -163,6 +165,7 @@ public class FullPlaybackActivity extends SlidingPlaybackActivity
 		mTrackView = (TextView)findViewById(R.id.track);
 		mYearView = (TextView)findViewById(R.id.year);
 		mComposerView = (TextView)findViewById(R.id.composer);
+		mPathView = (TextView)findViewById(R.id.path);
 		mFormatView = (TextView)findViewById(R.id.format);
 		mReplayGainView = (TextView)findViewById(R.id.replaygain);
 
@@ -475,6 +478,7 @@ public class FullPlaybackActivity extends SlidingPlaybackActivity
 		mTrack = null;
 		mYear = null;
 		mComposer = null;
+		mPath = null;
 		mFormat = null;
 		mReplayGain = null;
 
@@ -505,6 +509,7 @@ public class FullPlaybackActivity extends SlidingPlaybackActivity
 			}
 			mYear = year;
 
+			mPath = song.path;
 			StringBuilder sb = new StringBuilder(12);
 			sb.append(decodeMimeType(data.extractMetadata(MediaMetadataRetriever.METADATA_KEY_MIMETYPE)));
 			String bitrate = data.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE);
@@ -587,6 +592,7 @@ public class FullPlaybackActivity extends SlidingPlaybackActivity
 			mTrackView.setText(mTrack);
 			mYearView.setText(mYear);
 			mComposerView.setText(mComposer);
+			mPathView.setText(mPath);
 			mFormatView.setText(mFormat);
 			mReplayGainView.setText(mReplayGain);
 			break;


### PR DESCRIPTION
This pull commit displays the path of the currently playing file in the extended playing view. It could be useful for broken tags, finding the file quickly etc.. Unfortunately my Android and Java knowledge is close to zero, so I can't do much more (like not displaying the library path or only displaying the necessary characters of each folder to shorten the displayed string).

![screenshot_20160614-195210](https://cloud.githubusercontent.com/assets/11035569/16053654/0a0d8a5c-326a-11e6-81de-75f386ee1db9.png)
