### PR TITLE
Fixed onLoadChildren being way too slow

### DIFF
--- a/src/ch/blinkenlights/android/vanilla/CoverCache.java
+++ b/src/ch/blinkenlights/android/vanilla/CoverCache.java
@@ -392,7 +392,7 @@ public class CoverCache {
 				InputStream inputStream = null;
 				InputStream sampleInputStream = null; // same as inputStream but used for getSampleSize
 
-				if ((song.path != null) && (CoverCache.mCoverLoadMode & CoverCache.COVER_MODE_VANILLA) != 0) {
+				if ((CoverCache.mCoverLoadMode & CoverCache.COVER_MODE_VANILLA) != 0) {
 					final File baseFile  = new File(song.path);  // File object of queried song
 					String bestMatchPath = null;                 // The best cover-path we found
 					int bestMatchIndex   = COVER_MATCHES.length; // The best cover-index/priority found

--- a/src/ch/blinkenlights/android/vanilla/CoverCache.java
+++ b/src/ch/blinkenlights/android/vanilla/CoverCache.java
@@ -392,7 +392,7 @@ public class CoverCache {
 				InputStream inputStream = null;
 				InputStream sampleInputStream = null; // same as inputStream but used for getSampleSize
 
-				if ((CoverCache.mCoverLoadMode & CoverCache.COVER_MODE_VANILLA) != 0) {
+				if ((song.path != null) && (CoverCache.mCoverLoadMode & CoverCache.COVER_MODE_VANILLA) != 0) {
 					final File baseFile  = new File(song.path);  // File object of queried song
 					String bestMatchPath = null;                 // The best cover-path we found
 					int bestMatchIndex   = COVER_MATCHES.length; // The best cover-index/priority found


### PR DESCRIPTION
Hi Adrian,

Here are a couple of fixes to the MediaBrowserService backing up Vanilla's compatibility with MirrorLink.
Clearly at the time I wrote this I didn't fully understand the inner working of Vanilla and my way of retrieving the cover art was really bad.

It is way better now (far less content resolver accesses) but I needed to tweak cover cache a little to make sure a cover can be generated for a song with no path.

Let me know if you have any comments,

Best regards,
Laurent
