### PR TITLE
Vanilla: Add Tools to build in Android tree

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,20 @@
+LOCAL_PATH:= $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_SRC_FILES := \
+        $(call all-java-files-under, src)
+
+LOCAL_RESOURCE_DIR := $(LOCAL_PATH)/res
+
+LOCAL_PACKAGE_NAME := VanillaMusic
+
+LOCAL_AAPT_FLAGS := \
+    --auto-add-overlay
+
+include $(BUILD_PACKAGE)
+
+# Use the following include to make our test apk.
+ifeq (,$(ONE_SHOT_MAKEFILE))
+include $(call all-makefiles-under,$(LOCAL_PATH))
+endif

--- a/CleanSpec.mk
+++ b/CleanSpec.mk
@@ -1,0 +1,49 @@
+# Copyright (C) 2007 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# If you don't need to do a full clean build but would like to touch
+# a file or delete some intermediate files, add a clean step to the end
+# of the list.  These steps will only be run once, if they haven't been
+# run before.
+#
+# E.g.:
+#     $(call add-clean-step, touch -c external/sqlite/sqlite3.h)
+#     $(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/STATIC_LIBRARIES/libz_intermediates)
+#
+# Always use "touch -c" and "rm -f" or "rm -rf" to gracefully deal with
+# files that are missing or have been moved.
+#
+# Use $(PRODUCT_OUT) to get to the "out/target/product/blah/" directory.
+# Use $(OUT_DIR) to refer to the "out" directory.
+#
+# If you need to re-do something that's already mentioned, just copy
+# the command and add it to the bottom of the list.  E.g., if a change
+# that you made last week required touching a file and a change you
+# made today requires touching the same file, just copy the old
+# touch step and add it to the end of the list.
+#
+# ************************************************
+# NEWER CLEAN STEPS MUST BE AT THE END OF THE LIST
+# ************************************************
+
+# For example:
+#$(call add-clean-step, rm -rf $(OUT_DIR)/target/common/obj/APPS/AndroidTests_intermediates)
+#$(call add-clean-step, rm -rf $(OUT_DIR)/target/common/obj/JAVA_LIBRARIES/core_intermediates)
+#$(call add-clean-step, find $(OUT_DIR) -type f -name "IGTalkSession*" -print0 | xargs -0 rm -f)
+#$(call add-clean-step, rm -rf $(PRODUCT_OUT)/data/*)
+
+# ************************************************
+# NEWER CLEAN STEPS MUST BE AT THE END OF THE LIST
+# ************************************************

--- a/res/layout/filebrowser_content.xml
+++ b/res/layout/filebrowser_content.xml
@@ -26,25 +26,25 @@ THE SOFTWARE.
 	android:orientation="vertical" >
 
 	<LinearLayout
-		android:layout_width="fill_parent" 
+		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
 		android:orientation="horizontal" >
-	
+
 	<TextView
 		android:id="@+id/path_display"
 		android:layout_height="wrap_content"
 		android:layout_width="0dp"
 		android:layout_weight="2"
 		android:layout_marginLeft="@dimen/text_padding"
-		android:text="" />
+		android:text="@string/empty" />
 	<Button
 		android:id="@+id/save_button"
 		android:layout_height="wrap_content"
 		android:layout_width="0dp"
 		android:layout_weight="1"
 		android:text="@string/select" />
-	
-	</LinearLayout>	
+
+	</LinearLayout>
 
 	<TextView
 		android:layout_width="fill_parent"
@@ -61,4 +61,3 @@ THE SOFTWARE.
 		android:dividerHeight="1dip" />
 
 </LinearLayout>
-

--- a/res/layout/sdscanner_fragment.xml
+++ b/res/layout/sdscanner_fragment.xml
@@ -57,6 +57,5 @@ Copied from SD Scanner's layout/main.xml with minor changes
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:gravity="center_vertical"
-		android:text="" />
+		android:text="@string/empty" />
 </LinearLayout>
-

--- a/res/layout/seekbar_pref.xml
+++ b/res/layout/seekbar_pref.xml
@@ -49,7 +49,7 @@ THE SOFTWARE.
 		android:paddingRight="20dip"
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
-		android:text=""
+		android:text="@string/empty"
 	/>
 
 </LinearLayout>

--- a/res/values/untranslatable.xml
+++ b/res/values/untranslatable.xml
@@ -142,5 +142,7 @@ THE SOFTWARE.
 		<item>@string/fixed_info</item>
 	</string-array>
 
+	<string name="empty"></string>
+
 
 </resources>


### PR DESCRIPTION
Also workaround build errors about missing localisation of empty strings

Change-Id: I359bee2019eee7bf1bf59107bbd68cc2a0ee1dc8

Vanilla: Cleanup Android.mk

Change-Id: Icac01fa7bc89b32ecc45ca8991fcb19d0db5baf3