### PR TITLE
Add configuration and logic to ignore small audio files during scan.

### DIFF
--- a/res/layout/medialibrary_preferences.xml
+++ b/res/layout/medialibrary_preferences.xml
@@ -36,6 +36,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
 		android:text="@string/media_scan_drop_db" />
+	<CheckBox android:id="@+id/media_scan_ignore_small_files"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:text="@string/media_scan_ignore_small" />
 	<Button
 		android:id="@+id/start_button"
 		android:layout_width="wrap_content"

--- a/res/values/translatable.xml
+++ b/res/values/translatable.xml
@@ -307,6 +307,7 @@ THE SOFTWARE.
 	<string name="media_scan_header">Media scanner</string>
 	<string name="media_scan_full">Scan full filesystem (Slow)</string>
 	<string name="media_scan_drop_db">Flush media database (Dangerzone!)</string>
+	<string name="media_scan_ignore_small">Ignore abnormally small files</string>
 	<string name="media_scan_start">Start scan</string>
 	<string name="media_statistics">Statistics</string>
 

--- a/src/ch/blinkenlights/android/medialibrary/MediaLibrary.java
+++ b/src/ch/blinkenlights/android/medialibrary/MediaLibrary.java
@@ -78,13 +78,15 @@ public class MediaLibrary  {
 
 	/**
 	 * Triggers a rescan of the library
-	 *
-	 * @param context the context to use
+	 *  @param context the context to use
 	 * @param forceFull starts a full / slow scan if true
-	 * @param drop drop the existing library if true
-	 */
-	public static void scanLibrary(Context context, boolean forceFull, boolean drop) {
+     * @param drop drop the existing library if true
+     * @param ignoreSmallFiles ignore files less than a specific size.
+     */
+	public static void scanLibrary(Context context, boolean forceFull, boolean drop, boolean ignoreSmallFiles) {
 		MediaLibraryBackend backend = getBackend(context); // also initialized sScanner
+
+		sScanner.setIgnoreSmallFiles(ignoreSmallFiles);
 		if (drop) {
 			sScanner.flushDatabase();
 			// fixme: should clean orphaned AFTER scan finished

--- a/src/ch/blinkenlights/android/medialibrary/MediaScanner.java
+++ b/src/ch/blinkenlights/android/medialibrary/MediaScanner.java
@@ -40,6 +40,8 @@ import java.util.ArrayList;
 import java.util.regex.Pattern;
 
 public class MediaScanner implements Handler.Callback {
+	//Ignore MP3s smaller than 512Kb
+	private static final long MIN_FILE_LENGTH = 1024 * 512;
 	/**
 	 * Our scan plan
 	 */
@@ -69,6 +71,10 @@ public class MediaScanner implements Handler.Callback {
 	 * The id we are using for the scan notification
 	 */
 	private int NOTIFICATION_ID = 56162;
+	/**
+	 * If true skip files less than a specified size.
+	 */
+	private boolean mIgnoreSmallFiles = false;
 
 	MediaScanner(Context context, MediaLibraryBackend backend) {
 		mContext = context;
@@ -337,6 +343,10 @@ public class MediaScanner implements Handler.Callback {
 		if (isBlacklisted(file))
 			return false;
 
+		if (mIgnoreSmallFiles && isFileTooSmall(file)) {
+			return false;
+		}
+
 		long dbEntryMtime = mBackend.getSongMtime(songId) * 1000; // this is in unixtime -> convert to 'ms'
 		long fileMtime = file.lastModified();
 		boolean hasChanged = false;
@@ -458,6 +468,10 @@ public class MediaScanner implements Handler.Callback {
 		return hasChanged;
 	}
 
+	private boolean isFileTooSmall(File file) {
+		return file.length() < MIN_FILE_LENGTH;
+	}
+
 	private static final Pattern sIgnoredNames = Pattern.compile("^([^\\.]+|.+\\.(jpe?g|gif|png|bmp|webm|txt|pdf|avi|mp4|mkv|zip|tgz|xml))$", Pattern.CASE_INSENSITIVE);
 	/**
 	 * Returns true if the file should not be scanned
@@ -488,6 +502,10 @@ public class MediaScanner implements Handler.Callback {
 		}
 
 		return oldVal;
+	}
+
+	public void setIgnoreSmallFiles(boolean ignoreSmallFiles) {
+		this.mIgnoreSmallFiles = ignoreSmallFiles;
 	}
 
 

--- a/src/ch/blinkenlights/android/vanilla/PreferencesMediaLibrary.java
+++ b/src/ch/blinkenlights/android/vanilla/PreferencesMediaLibrary.java
@@ -58,6 +58,10 @@ public class PreferencesMediaLibrary extends Fragment
 	 */
 	private CheckBox mFullScanCheck;
 	/**
+	 * Ignore files smaller than ch.blinkenlights.android.medialibrary.MediaScanner#MIN_FILE_LENGTH
+	 */
+	private CheckBox mIgnoreSmallFiles;
+	/**
 	 * Checkbox for drop
 	 */
 	private CheckBox mDropDbCheck;
@@ -76,6 +80,7 @@ public class PreferencesMediaLibrary extends Fragment
 		mStatsTracks = (TextView)view.findViewById(R.id.media_stats_tracks);
 		mStatsPlaytime = (TextView)view.findViewById(R.id.media_stats_playtime);
 		mFullScanCheck = (CheckBox)view.findViewById(R.id.media_scan_full);
+		mIgnoreSmallFiles = (CheckBox)view.findViewById(R.id.media_scan_ignore_small_files);
 		mDropDbCheck = (CheckBox)view.findViewById(R.id.media_scan_drop_db);
 
 		mStartButton.setOnClickListener(new View.OnClickListener() {
@@ -152,7 +157,7 @@ public class PreferencesMediaLibrary extends Fragment
 	 * @param view the view which was pressed
 	 */
 	public void startButtonPressed(View view) {
-		MediaLibrary.scanLibrary(getActivity(), mFullScanCheck.isChecked(), mDropDbCheck.isChecked());
+		MediaLibrary.scanLibrary(getActivity(), mFullScanCheck.isChecked(), mDropDbCheck.isChecked(), mIgnoreSmallFiles.isChecked());
 		updateProgress();
 	}
 


### PR DESCRIPTION
This is a feature I wanted as a user as I have various small audio files on my SD card that I do not want to show up in my music player.  I realize this may not be a 'general purpose' feature and leave it to the Vanilla maintainers as to whether it's worth taking or not. 