### PR TITLE
Add less-intrusive nightly configuration for gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'com.android.application'
 android {
     lintOptions {
         disable 'MissingTranslation'
+        disable 'ExtraTranslation'
     }
 
     compileSdkVersion 25
@@ -34,15 +35,40 @@ android {
         main {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
-            resources.srcDirs = ['src']
             aidl.srcDirs = ['src']
-            renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
+        }
+
+        nightly {
+            res.srcDirs = ['resNightly']
         }
     }
 
     buildTypes {
+        nightly {
+            def buildId = 'date +%s'.execute().in.readLines()[0]
+
+            versionNameSuffix '-' + buildId
+            applicationIdSuffix '.nightly'
+
+            preBuild.finalizedBy 'customPrepareResources'
+
+            task ('customPrepareResources') {
+                doLast {
+                    println 'Converting icons to nightly...'
+                    fileTree('res').include('drawable-*/icon.png').each {
+                        println it
+                        "mogrify -fuzz 40% -fill 'rgb(0,102,102)' -opaque 'rgb(255,102,0)' $it".execute()
+                    }
+
+                    println 'Replacing `about` info to nightly...'
+                    def about = file('assets/about.html')
+                    about.text = about.text.replaceAll('<b>Version.*', "<b>Nightly build ID:</b> ${buildId}<br><br>")
+                }
+            }
+        }
+
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'

--- a/res/xml/preference_audio.xml
+++ b/res/xml/preference_audio.xml
@@ -22,7 +22,7 @@ THE SOFTWARE.
 -->
 <PreferenceScreen
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:vanilla="http://schemas.android.com/apk/res/ch.blinkenlights.android.vanilla"
+	xmlns:vanilla="http://schemas.android.com/apk/res-auto"
 	android:persistent="true">
 	<PreferenceScreen
 		android:fragment="ch.blinkenlights.android.vanilla.PreferencesActivity$EqualizerFragment"

--- a/res/xml/preference_misc.xml
+++ b/res/xml/preference_misc.xml
@@ -22,7 +22,7 @@ THE SOFTWARE.
 -->
 <PreferenceScreen
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:vanilla="http://schemas.android.com/apk/res/ch.blinkenlights.android.vanilla"
+	xmlns:vanilla="http://schemas.android.com/apk/res-auto"
 	android:persistent="true">
 	<CheckBoxPreference
 		android:key="disable_lockscreen"

--- a/res/xml/preference_replaygain.xml
+++ b/res/xml/preference_replaygain.xml
@@ -22,7 +22,7 @@ THE SOFTWARE.
 -->
 <PreferenceScreen
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:vanilla="http://schemas.android.com/apk/res/ch.blinkenlights.android.vanilla"
+	xmlns:vanilla="http://schemas.android.com/apk/res-auto"
 	android:persistent="true">
 	<CheckBoxPreference
 		android:key="enable_track_replaygain"
@@ -57,11 +57,11 @@ THE SOFTWARE.
 		vanilla:sbpSummaryFormat="%s %.1fdB"
 		vanilla:sbpSummaryValueAddition="-150"
 		vanilla:sbpSummaryValueMultiplication="0.1" />
-		
+
 	<Preference
 		android:selectable="false"
 		android:title="@string/replaygain_preamp_note_title"
 		android:summary="@string/replaygain_preamp_note_content"
 		/>
-		
+
 </PreferenceScreen>

--- a/res/xml/preference_shake.xml
+++ b/res/xml/preference_shake.xml
@@ -22,7 +22,7 @@ THE SOFTWARE.
 -->
 <PreferenceScreen
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:vanilla="http://schemas.android.com/apk/res/ch.blinkenlights.android.vanilla"
+	xmlns:vanilla="http://schemas.android.com/apk/res-auto"
 	android:persistent="true">
 	<CheckBoxPreference
 		android:key="enable_shake"

--- a/resNightly/values/translatable.xml
+++ b/resNightly/values/translatable.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2017 Oleg `Kanedias` Chernovskiy <kanedias@xaker.ru>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<resources>
+	<string name="app_name">Vanilla Music Nightly</string>
+</resources>


### PR DESCRIPTION
@adrian-bl , please use this instead of nightly script
```bash
./gradlew assembleNightly
```
Feel free to change at will (e.g. hostname can be added, etc)

- Does not require moves
- Does not change inner strings, allowing plugins to work in Nightly
- fixes vanilla-music/vanilla-music-tag-editor/issues/4