### PR TITLE
Issue #530 Added ability to exclude songs from being included in shuffle random mode

### DIFF
--- a/res/values/translatable.xml
+++ b/res/values/translatable.xml
@@ -80,6 +80,8 @@ THE SOFTWARE.
 	<string name="play_or_enqueue">Enqueue if playing; Play if paused</string>
 	<string name="open">Open</string>
 	<string name="go_home">Home directory</string>
+	<string name="exclude_from_shuffle">Exclude from shuffle</string>
+	<string name="include_in_shuffle">Include in shuffle</string>
 
 	<plurals name="playing">
 		<item quantity="one">1 track playing.</item>

--- a/src/ch/blinkenlights/android/medialibrary/MediaLibraryBackend.java
+++ b/src/ch/blinkenlights/android/medialibrary/MediaLibraryBackend.java
@@ -17,12 +17,13 @@
 
 package ch.blinkenlights.android.medialibrary;
 
-import android.content.Context;
 import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.database.Cursor;
 import android.util.Log;
+
 import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -35,7 +36,7 @@ public class MediaLibraryBackend extends SQLiteOpenHelper {
 	/**
 	 * The database version we are using
 	 */
-	private static final int DATABASE_VERSION = 20170217;
+	private static final int DATABASE_VERSION = 20170311;
 	/**
 	 * on-disk file to store the database
 	 */

--- a/src/ch/blinkenlights/android/medialibrary/MediaSchema.java
+++ b/src/ch/blinkenlights/android/medialibrary/MediaSchema.java
@@ -240,6 +240,12 @@ public class MediaSchema {
 	  +" ;";
 
 	/**
+	 * Add no shuffle column to songs table
+	 */
+	private static final String DATABASE_SONGS_ADD_NO_SHUFFLE_COLUMN = "ALTER TABLE " + MediaLibrary.TABLE_SONGS + " ADD COLUMN " + MediaLibrary.SongColumns.NO_SHUFFLE + " INTEGER";
+
+
+	/**
 	 * Creates a new database schema on dbh
 	 *
 	 * @param dbh the writeable dbh to act on
@@ -264,6 +270,7 @@ public class MediaSchema {
 		dbh.execSQL(VIEW_CREATE_COMPOSERS);
 		dbh.execSQL(VIEW_CREATE_PLAYLIST_SONGS);
 		dbh.execSQL(DATABASE_CREATE_PREFERENCES);
+		dbh.execSQL(DATABASE_SONGS_ADD_NO_SHUFFLE_COLUMN);
 	}
 
 	/**
@@ -300,6 +307,10 @@ public class MediaSchema {
 			dbh.execSQL(VIEW_CREATE_ALBUMARTISTS);
 			dbh.execSQL(VIEW_CREATE_COMPOSERS);
 			dbh.execSQL(VIEW_CREATE_SONGS_ALBUMS_ARTISTS_HUGE);
+		}
+
+		if(oldVersion < 20170311) {
+			dbh.execSQL(DATABASE_SONGS_ADD_NO_SHUFFLE_COLUMN);
 		}
 
 	}

--- a/src/ch/blinkenlights/android/vanilla/MediaUtils.java
+++ b/src/ch/blinkenlights/android/vanilla/MediaUtils.java
@@ -22,8 +22,15 @@
 
 package ch.blinkenlights.android.vanilla;
 
-import ch.blinkenlights.android.medialibrary.MediaLibrary;
-import ch.blinkenlights.android.medialibrary.MediaMetadataExtractor;
+import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.os.Environment;
+import android.provider.MediaStore;
+import android.widget.Toast;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -33,21 +40,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import android.util.Log;
-
-import junit.framework.Assert;
-
-import android.content.ActivityNotFoundException;
-import android.content.Context;
-import android.content.Intent;
-import android.database.Cursor;
-import android.net.Uri;
-import android.os.Environment;
-import android.provider.MediaStore;
-import android.text.TextUtils;
-import android.database.MatrixCursor;
-import android.util.Log;
-import android.widget.Toast;
+import ch.blinkenlights.android.medialibrary.MediaLibrary;
+import ch.blinkenlights.android.medialibrary.MediaMetadataExtractor;
 
 
 /**
@@ -342,7 +336,8 @@ public class MediaUtils {
 	 * @param context The Context to use
 	 */
 	private static long[] queryAllSongs(Context context) {
-		QueryTask query = new QueryTask(MediaLibrary.TABLE_SONGS, Song.EMPTY_PROJECTION, null, null, null);
+		QueryTask query = new QueryTask(MediaLibrary.TABLE_SONGS, Song.EMPTY_PROJECTION,
+                MediaLibrary.SongColumns.NO_SHUFFLE + " != 1 OR " + MediaLibrary.SongColumns.NO_SHUFFLE + " ISNULL", null, null);
 		Cursor cursor = query.runQuery(context);
 		if (cursor == null || cursor.getCount() == 0) {
 			sSongCount = 0;


### PR DESCRIPTION
The ability to toggle excluding/including songs from shuffle is only exposed via a context menu selection in the Files view