### PR TITLE
Mark notifications showing media content as private.

### DIFF
--- a/src/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/src/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -2103,8 +2103,6 @@ public final class PlaybackService extends Service
 			notification.bigContentView = expanded;
 		}
 		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-			notification.visibility = Notification.VISIBILITY_PUBLIC;
-
 			RemoteViews viewsPublic = new RemoteViews(getPackageName(), R.layout.notification);
 			viewsPublic.setInt(R.id.title, "setText", R.string.app_name);
 
@@ -2118,7 +2116,6 @@ public final class PlaybackService extends Service
 			Notification notificationPublic = notification.clone();
 			notificationPublic.contentView = viewsPublic;
 
-			notification.visibility = Notification.VISIBILITY_PRIVATE;
 			notification.publicVersion = notificationPublic;
 		}
 

--- a/src/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/src/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -2104,6 +2104,22 @@ public final class PlaybackService extends Service
 		}
 		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 			notification.visibility = Notification.VISIBILITY_PUBLIC;
+
+			RemoteViews viewsPublic = new RemoteViews(getPackageName(), R.layout.notification);
+			viewsPublic.setInt(R.id.title, "setText", R.string.app_name);
+
+			viewsPublic.setImageViewResource(R.id.cover, R.drawable.icon);
+			viewsPublic.setImageViewResource(R.id.play_pause, playButton);
+			viewsPublic.setOnClickPendingIntent(R.id.play_pause, PendingIntent.getService(this, 0, playPause, 0));
+			viewsPublic.setOnClickPendingIntent(R.id.next, PendingIntent.getService(this, 0, next, 0));
+			viewsPublic.setOnClickPendingIntent(R.id.close, PendingIntent.getService(this, 0, close, 0));
+			viewsPublic.setViewVisibility(R.id.close, closeButtonVisibility);
+
+			Notification notificationPublic = notification.clone();
+			notificationPublic.contentView = viewsPublic;
+
+			notification.visibility = Notification.VISIBILITY_PRIVATE;
+			notification.publicVersion = notificationPublic;
 		}
 
 		if(mNotificationNag) {


### PR DESCRIPTION
Revised version of pull request #600.

Separate public and private notifications are created.
Presentation depends on Android security.
No settings within Vanilla are added.

Tested on Android 7.1 (LineageOS, real device).

I tried testing using the Android emulator for Android 4.X using Android Studio 2.3.2 (Linux and Windows).
However, I was unable to convince Vanilla to find music files (don't know why).