### PR TITLE
Explicitly accept album art as saved by Windows Media Player

### DIFF
--- a/src/ch/blinkenlights/android/vanilla/CoverCache.java
+++ b/src/ch/blinkenlights/android/vanilla/CoverCache.java
@@ -199,7 +199,11 @@ public class CoverCache {
 		/**
 		 * Priority-ordered list of possible cover names
 		 */
-		private final static Pattern[] COVER_MATCHES = { Pattern.compile("(?i).+/(COVER|ALBUM)\\.(JPE?G|PNG)$"), Pattern.compile("(?i).+/(CD|FRONT|ARTWORK)\\.(JPE?G|PNG)$"), Pattern.compile("(?i).+\\.(JPE?G|PNG)$") };
+		private final static Pattern[] COVER_MATCHES = {
+			    Pattern.compile("(?i).+/(COVER|ALBUM)\\.(JPE?G|PNG)$"),
+			    Pattern.compile("(?i).+/ALBUMART(_\\{[-0-9A-F]+\\}_LARGE)?\\.(JPE?G|PNG)$"),
+			    Pattern.compile("(?i).+/(CD|FRONT|ARTWORK|FOLDER)\\.(JPE?G|PNG)$"),
+			    Pattern.compile("(?i).+\\.(JPE?G|PNG)$") };
 		/**
 		 * Projection of all columns in the database
 		 */


### PR DESCRIPTION
Windows Media Player saves album covers in AlbumArt* files. Since 2011
Android has considered them as non-media files[1] and hasn't shown in
the Gallery application.

[1] https://android.googlesource.com/platform/frameworks/base/+/ade06df0fe3499d66ee5cc29071d41445d1091fa