### PR TITLE
Remote control and albums identification improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 
@@ -23,7 +23,6 @@ android {
     }
 
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
 
     defaultConfig {
         applicationId "ch.blinkenlights.android.vanilla"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
@@ -10,6 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }
@@ -50,4 +52,8 @@ android {
     lintOptions {
         abortOnError false
     }
+}
+
+dependencies {
+    implementation 'com.android.support:support-annotations:27.0.2'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Sun May 28 17:31:34 MSK 2017
+#Fri Jan 26 17:08:07 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
 distributionSha256Sum=71a787faed83c4ef21e8464cc8452b941b5fcd575043aa29d39d15d879be89f7

--- a/src/ch/blinkenlights/android/medialibrary/MediaSchema.java
+++ b/src/ch/blinkenlights/android/medialibrary/MediaSchema.java
@@ -166,7 +166,7 @@ public class MediaSchema {
 	  +" ;";
 
 	/**
-	 * View wich includes SONGS_ALBUMS_ARTISTS and any other contributors
+	 * View which includes SONGS_ALBUMS_ARTISTS and any other contributors
 	 * This view should only be used if needed as the SQL query is pretty expensive
 	 */
 	private static final String VIEW_CREATE_SONGS_ALBUMS_ARTISTS_HUGE = "CREATE VIEW "+ MediaLibrary.VIEW_SONGS_ALBUMS_ARTISTS_HUGE+" AS "

--- a/src/ch/blinkenlights/android/vanilla/MediaButtonReceiver.java
+++ b/src/ch/blinkenlights/android/vanilla/MediaButtonReceiver.java
@@ -199,7 +199,7 @@ public class MediaButtonReceiver extends BroadcastReceiver {
 
 
 	/**
-	 * Runable to run a delayed action
+	 * Runnable to run a delayed action
 	 * Inspects sLastClickTime and sDelayedClicks to guess what to do
 	 *
 	 * @param context the context to use

--- a/src/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/src/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -1104,7 +1104,7 @@ public final class PlaybackService extends Service
 		if (mReadaheadEnabled)
 			triggerReadAhead();
 
-		mRemoteControlClient.updateRemote(mCurrentSong, mState, mForceNotificationVisible);
+		mRemoteControlClient.updateRemote(mCurrentSong, mState, mForceNotificationVisible, uptime);
 
 		scrobbleBroadcast();
 	}
@@ -1697,6 +1697,18 @@ public final class PlaybackService extends Service
 			return;
 		long position = (long)mMediaPlayer.getDuration() * progress / 1000;
 		mMediaPlayer.seekTo((int)position);
+		mHandler.sendMessage(mHandler.obtainMessage(MSG_BROADCAST_CHANGE, -1, 0, new TimestampedObject(null)));
+	}
+
+	/**
+	 * Broadcast an update with a delay.
+	 * This is only needed to implement a hack to force correct progress display when playing for the first time after process start.
+	 *
+	 * @param delayMillis Delay of the broadcast in milliseconds
+	 */
+	public void broadcastUpdateDelayed(long delayMillis)
+	{
+		mHandler.sendMessageDelayed(mHandler.obtainMessage(MSG_BROADCAST_CHANGE, -1, 0, new TimestampedObject(null)), delayMillis);
 	}
 
 	@Override

--- a/src/ch/blinkenlights/android/vanilla/RemoteControl.java
+++ b/src/ch/blinkenlights/android/vanilla/RemoteControl.java
@@ -40,6 +40,6 @@ public class RemoteControl {
 		public void initializeRemote();
 		public void unregisterRemote();
 		public void reloadPreference();
-		public void updateRemote(Song song, int state, boolean keepPaused);
+		public void updateRemote(Song song, int state, boolean keepPaused, long updateTime);
 	}
 }

--- a/src/ch/blinkenlights/android/vanilla/RemoteControlImplICS.java
+++ b/src/ch/blinkenlights/android/vanilla/RemoteControlImplICS.java
@@ -120,7 +120,7 @@ public class RemoteControlImplICS implements RemoteControl.Client {
 	 * @param state PlaybackService state, used to determine playback state.
 	 * @param keepPaused whether or not to keep the remote updated in paused mode
 	 */
-	public void updateRemote(Song song, int state, boolean keepPaused)
+	public void updateRemote(Song song, int state, boolean keepPaused, long updateTime)
 	{
 		RemoteControlClient remote = mRemote;
 		if (remote == null)


### PR DESCRIPTION
Make the Album artist be listed as the album's Primary artist and distinguish albums by the combination of (Album name, Album artist).
Ensure remote is notified of the correct playback progress in all scenarios attempted.
