### PR TITLE
Fix missing metadata at start using MediaBrowserService

### DIFF
--- a/src/ch/blinkenlights/android/vanilla/MirrorLinkMediaBrowserService.java
+++ b/src/ch/blinkenlights/android/vanilla/MirrorLinkMediaBrowserService.java
@@ -184,6 +184,7 @@ public class MirrorLinkMediaBrowserService extends MediaBrowserService
 		mHandler = new Handler(mLooper, this);
 
 		updatePlaybackState(null);
+		setSong(0, null);
 	}
 
 	@Override


### PR DESCRIPTION
Hello.
We are working on the RockScout which using the Vanilla Music as media provider. We noticed one issue which should be fixed after this changes.

To reproduce this issue we need app which using MediaBrowserService (for example the RockScout)

**Steps to reproduce:**
1. Force stop the Vanilla Music and the RockScout app.
2. Open the RockScout.
3. Select Vanilla Music provider, then click "Now Playing"
4. Click play.

**Result:**
Music is playing but missing metadata.

After click next/prev song everything is ok. This issue exist only at first connection to MediaBrowserService when the Vanilla Music isn't running. 