### PR TITLE
Add "media/audio" to library default blacklist

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaLibrary.java
+++ b/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaLibrary.java
@@ -189,7 +189,7 @@ public class MediaLibrary  {
 	 * @return array with guessed blacklist
 	 */
 	private static ArrayList<String> discoverDefaultBlacklistedPaths(Context context) {
-		final String[] defaultBlacklistPostfix = { "Android/data", "Alarms", "Notifications", "Ringtones" };
+		final String[] defaultBlacklistPostfix = { "Android/data", "Alarms", "Notifications", "Ringtones", "media/audio" };
 		ArrayList<String> defaultPaths = new ArrayList<>();
 
 		for (String path : discoverDefaultMediaPaths(context)) {


### PR DESCRIPTION
The media/audio folder can be used as an alternative combined folder to add custom sounds to various android choosers.

This folder may hold for example the following subdirectories:
* alarms (/sdcard/Alarms alternative)
* notifications (/sdcard/Notifications alternative)
* ringtones (/sdcard/Ringtones alternative)
* ui (dont know if /sdcard/Ui is also such a directory)

All of these are scanned by Android in the same way like the other special directories.
As they hold e.g. click or short alarm sounds or like that they are not needed in music player ;).