### PR TITLE
Editor config and annotations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root=true
+
+[*]
+charset=utf-8
+# Unix-style newlines with a newline ending every file
+end_of_line=lf
+insert_final_newline=true
+indent_style=tab
+tab_width=4

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Contributing code
 ---------------
 * A list of open issues can be found at the [issue tracker][2]
 * Features we would like to see (but nobody started working on them yet) have the [patches-welcome][3] label attached to them. Please let us know if you start working on such an open issue (to avoid duplicate work)
-* We accept raw patches and github pull request - and we use tabs.
+* We accept raw patches and github pull request - and we use tabs (if your editor understands .editorconfig, it will help you enforce this).
 
 Building
 ========

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,3 +25,7 @@ android {
         abortOnError false
     }
 }
+
+dependencies {
+    compileOnly 'com.android.support:support-annotations:27.0.2'
+}


### PR DESCRIPTION
#### Annotations:
Annotations support allows making code look cleaner (e.g. `@NonNull` or `@Nullable` etc. JSR-305). It is not specific to Android Studio and is used during compilation.

#### Editor config:
I have a sane Android Studio editor, and even though it automatically detects coding conventions already present in the sources and keeps my changes consistent with them, it pops a yellow warning bar on top of the text editor telling me that it replaced spaces with tabs to follow the document's formatting style but that does not match my editor preferences.
.editorconfig is the clean way to avoid any such inconsistencies and tell any sane editor what are the project's preferences that should override any globally configured user's preferences.
This "clutter" is truly minimal and so not worth avoiding.
