### PR TITLE
Add library action expand or play all. Implements #488.

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
@@ -108,9 +108,13 @@ public class LibraryActivity
 	 */
 	public static final int ACTION_PLAY_OR_ENQUEUE = 7;
 	/**
-	 * Action for row click: queue selection as next item
+	 * Action for row click: queue selection as next item.
 	 */
 	public static final int ACTION_ENQUEUE_AS_NEXT = 8;
+	/**
+	 * Action for row click: expand or play all.
+	 */
+	public static final int ACTION_EXPAND_OR_PLAY_ALL = 9;
 	/**
 	 * The SongTimeline add song modes corresponding to each relevant action.
 	 */
@@ -451,13 +455,16 @@ public class LibraryActivity
 		if (action == ACTION_LAST_USED)
 			action = mLastAction;
 
-		if (action == ACTION_EXPAND && rowData.getBooleanExtra(LibraryAdapter.DATA_EXPANDABLE, false)) {
+		boolean tryExpand = action == ACTION_EXPAND || action == ACTION_EXPAND_OR_PLAY_ALL;
+		if (tryExpand && rowData.getBooleanExtra(LibraryAdapter.DATA_EXPANDABLE, false)) {
 			onItemExpanded(rowData);
 		} else if (action != ACTION_DO_NOTHING) {
 			if (action == ACTION_EXPAND) {
 				// default to playing when trying to expand something that can't
 				// be expanded
 				action = ACTION_PLAY;
+			} else if (action == ACTION_EXPAND_OR_PLAY_ALL) {
+				action = ACTION_PLAY_ALL;
 			} else if (action == ACTION_PLAY_OR_ENQUEUE) {
 				action = (mState & PlaybackService.FLAG_PLAYING) == 0 ? ACTION_PLAY : ACTION_ENQUEUE;
 			}

--- a/app/src/main/res/values-de/translatable.xml
+++ b/app/src/main/res/values-de/translatable.xml
@@ -49,6 +49,7 @@
   <string name="playlist_favorites">Favoriten</string>
   <string name="new_playlist">Neue Wiedergabeliste …</string>
   <string name="expand">Aufklappen</string>
+  <string name="expand_or_play_all">Aufklappen oder alle wiedergeben</string>
   <string name="delete">Löschen</string>
   <string name="playback_view">Aktueller Titel</string>
   <string name="sort_by">Sortieren nach</string>

--- a/app/src/main/res/values/translatable.xml
+++ b/app/src/main/res/values/translatable.xml
@@ -73,6 +73,7 @@ THE SOFTWARE.
 	<string name="playlist_favorites">Favorites</string>
 	<string name="new_playlist">New playlist…</string>
 	<string name="expand">Expand</string>
+	<string name="expand_or_play_all">Expand or play all</string>
 	<string name="delete">Delete</string>
 	<string name="playback_view">Now playing</string>
 	<string name="sort_by">Sort by</string>

--- a/app/src/main/res/values/untranslatable.xml
+++ b/app/src/main/res/values/untranslatable.xml
@@ -110,18 +110,20 @@ THE SOFTWARE.
 		<item>@string/enqueue_all</item>
 		<item>@string/play_or_enqueue</item>
 		<item>@string/enqueue_as_next</item>
+		<item>@string/expand_or_play_all</item>
 		<item>@string/do_nothing</item>
 	</string-array>
 	<string-array name="default_action_entry_values">
-		<item>6</item> <!-- expand           -->
-		<item>0</item> <!-- play             -->
-		<item>1</item> <!-- enqueue          -->
-		<item>2</item> <!-- last_action_used -->
-		<item>3</item> <!-- play_all         -->
-		<item>4</item> <!-- enqueue_all      -->
-		<item>7</item> <!-- play_or_enqueue  -->
-		<item>8</item> <!-- enqueue_as_next  -->
-		<item>5</item> <!-- do_nothing       -->
+		<item>6</item> <!-- expand             -->
+		<item>0</item> <!-- play               -->
+		<item>1</item> <!-- enqueue            -->
+		<item>2</item> <!-- last_action_used   -->
+		<item>3</item> <!-- play_all           -->
+		<item>4</item> <!-- enqueue_all        -->
+		<item>7</item> <!-- play_or_enqueue    -->
+		<item>8</item> <!-- enqueue_as_next    -->
+		<item>9</item> <!-- expand_or_play_all -->
+		<item>5</item> <!-- do_nothing         -->
 	</string-array>
 	<!-- END default action entries definition -->
 


### PR DESCRIPTION
Like with the expand action it will first try to expand a selected item. If the item can't be expanded it will use play all instead of play.
So when you select a song from the middle of an album the queue will contain that song and all remaining songs from that album.