### PR TITLE
Fix duplicated shuffle active mode.

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/MirrorLinkMediaBrowserService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/MirrorLinkMediaBrowserService.java
@@ -699,7 +699,6 @@ public class MirrorLinkMediaBrowserService extends MediaBrowserService
 	private static final int[] SHUFFLE_ICONS =
 		{ 	R.drawable.shuffle_inactive_service
 		  , R.drawable.shuffle_active
-		  , R.drawable.shuffle_active
 		  , R.drawable.shuffle_album_active };
 
 	private void setCustomAction(PlaybackState.Builder stateBuilder) {


### PR DESCRIPTION
Hello.
We are working on the RockScout which using the Vanilla Music as media provider. We noticed issue with shuffle mode which should be fixed after this changes.

To reproduce this issue we need app which using MediaBrowserService (for example the RockScout).

Steps to reproduce:
1. Open the RockScout.
2. Select Vanilla Music provider, then click "Now Playing".
3. Change shuffle status several times.

Result:
Two times appear shuffle active mode.