### PR TITLE
Include song title, ablum and artist in scrobble broadcast even when there is no Android media ID.

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -1161,10 +1161,10 @@ public final class PlaybackService extends Service
 		if (mStockBroadcast) {
 			Intent intent = new Intent("com.android.music.playstatechanged");
 			intent.putExtra("playing", (mState & FLAG_PLAYING) != 0);
+			intent.putExtra("track", song.title);
+			intent.putExtra("album", song.album);
+			intent.putExtra("artist", song.artist);
 			if (androidIds[0] != -1) {
-				intent.putExtra("track", song.title);
-				intent.putExtra("album", song.album);
-				intent.putExtra("artist", song.artist);
 				intent.putExtra("songid", androidIds[0]);
 				intent.putExtra("albumid", androidIds[1]);
 			}


### PR DESCRIPTION
In this section of code, none of my music has Android music IDs. I'm guessing this is because none of it is in Android's media database. I don't see any reason not to include track, album and artist in the broadcast when this is the case.

As it is now, these details aren't in the broadcasts on my phone, so my scrobbler cannot scrobble my plays.