### PR TITLE
Add option to scroll to new track on song change

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PrefDefaults.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PrefDefaults.java
@@ -70,6 +70,7 @@ public class PrefDefaults {
 	public static final int     AUTOPLAYLIST_PLAYCOUNTS = 0;
 	public static final boolean IGNORE_AUDIOFOCUS_LOSS = false;
 	public static final boolean ENABLE_SCROLL_TO_SONG = false;
+	public static final boolean QUEUE_ENABLE_SCROLL_TO_SONG = false;
 	public static final boolean KEEP_SCREEN_ON = false;
 	public static final String  PLAYLIST_SYNC_MODE = "0";
 	public static final String  PLAYLIST_SYNC_FOLDER = "/sdcard/Playlists";

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PrefKeys.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PrefKeys.java
@@ -71,6 +71,7 @@ public class PrefKeys {
 	public static final String AUTOPLAYLIST_PLAYCOUNTS = "playcounts_autoplaylist";
 	public static final String IGNORE_AUDIOFOCUS_LOSS = "ignore_audiofocus_loss";
 	public static final String ENABLE_SCROLL_TO_SONG = "enable_scroll_to_song";
+	public static final String QUEUE_ENABLE_SCROLL_TO_SONG = "queue_enable_scroll_to_song";
 	public static final String KEEP_SCREEN_ON = "keep_screen_on";
 	public static final String PLAYLIST_SYNC_MODE = "playlist_sync_mode";
 	public static final String PLAYLIST_SYNC_FOLDER = "playlist_sync_folder";

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/ShowQueueFragment.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/ShowQueueFragment.java
@@ -21,6 +21,7 @@ import android.annotation.SuppressLint;
 import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
@@ -237,7 +238,11 @@ public class ShowQueueFragment extends Fragment
 	 */
 	public void onTimelineChanged() {
 		if (PlaybackService.hasInstance()) {
-			refreshSongQueueList(false);
+			boolean shouldScroll = PlaybackService
+				.getSettings(getActivity().getApplicationContext())
+				.getBoolean(PrefKeys.QUEUE_ENABLE_SCROLL_TO_SONG,
+					PrefDefaults.QUEUE_ENABLE_SCROLL_TO_SONG);
+			refreshSongQueueList(shouldScroll);
 		}
 	}
 

--- a/app/src/main/res/values/translatable.xml
+++ b/app/src/main/res/values/translatable.xml
@@ -249,6 +249,9 @@ THE SOFTWARE.
 	<string name="enable_scroll_to_song_title">Scroll to track title</string>
 	<string name="enable_scroll_to_song_summary">Scroll to currently playing track/album/artist in library lists</string>
 
+	<string name="queue_enable_scroll_to_song_title">Scroll to track title in queue</string>
+	<string name="queue_enable_scroll_to_song_summary">Scroll to currently playing track in the queue on song change</string>
+
 	<string name="coverloader_android_title">Load artwork from Android</string>
 	<string name="coverloader_android_summary">Query Androids internal media database for album artwork</string>
 

--- a/app/src/main/res/xml/preference_library.xml
+++ b/app/src/main/res/xml/preference_library.xml
@@ -47,6 +47,11 @@ THE SOFTWARE.
 		android:title="@string/enable_scroll_to_song_title"
 		android:summary="@string/enable_scroll_to_song_summary"
 		android:defaultValue="false" />
+	<CheckBoxPreference
+		android:key="queue_enable_scroll_to_song"
+		android:title="@string/queue_enable_scroll_to_song_title"
+		android:summary="@string/queue_enable_scroll_to_song_summary"
+		android:defaultValue="false" />
 	<PreferenceScreen
 		android:title="@string/filebrowser_start"
 		android:summary="@string/customize_filebrowser_start">


### PR DESCRIPTION
Adds a new setting to scroll the queue to the new song after a song
change. The new song will be at the top of the view.

Kind of fixes #798