### PR TITLE
Scroll the queue only when the requested song is not on screen

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/ShowQueueFragment.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/ShowQueueFragment.java
@@ -187,8 +187,13 @@ public class ShowQueueFragment extends Fragment
 			public void run() {
 				mListAdapter.setData(service, pos);
 
-				if(scroll)
-					scrollToCurrentSong(pos);
+				if(scroll) {
+					// check that we really need to jump to this song, i.e. it is not visible in list right now
+					int min = mListView.getFirstVisiblePosition();
+					int max = mListView.getLastVisiblePosition();
+					if (pos < min || pos > max) // it's out of visible range, scroll
+						scrollToCurrentSong(pos);
+				}
 			}
 		});
 		mIsPopulated = true;


### PR DESCRIPTION
Now if the option "scroll to the queue position" is enabled and
a user is selecting a song in queue it immediately disappears from under
the finger and jumps to the top of currently visible list.

This patch fixes this behaviour - only scroll if next (or previous) song
falls out of list view visible range. I.e. sudden scrolling will never
happen if user clicks an item in queue as it's currently visible.

------

I like the new option but I'm just sick of this new jerking behaviour.