### PR TITLE
Update plugin waking code, fix crash on Oreo devices

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackActivity.java
@@ -72,6 +72,12 @@ public abstract class PlaybackActivity extends Activity
 	           View.OnClickListener,
 	           CoverView.Callback
 {
+	/**
+	 * This constant is unavailable on Android < N.
+	 * For newer versions the constant is {@link Intent.FLAG_RECEIVER_INCLUDE_BACKGROUND}
+	 */
+	private static final int FLAG_RECEIVER_INCLUDE_BACKGROUND = 0x01000000;
+
 	private Action mUpAction;
 	private Action mDownAction;
 
@@ -742,7 +748,7 @@ public abstract class PlaybackActivity extends Activity
 		mLastRequestedCtx = songIntent;
 		Intent requestPlugins = new Intent(PluginUtils.ACTION_REQUEST_PLUGIN_PARAMS);
 		requestPlugins.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
-		requestPlugins.addFlags(0x01000000); // Intent.FLAG_RECEIVER_INCLUDE_BACKGROUND
+		requestPlugins.addFlags(FLAG_RECEIVER_INCLUDE_BACKGROUND);
 		sendBroadcast(requestPlugins);
 	}
 

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackActivity.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
@@ -49,6 +50,7 @@ import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.Message;
 import android.os.Process;
+import android.util.Log;
 import android.view.ContextMenu;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -733,12 +735,14 @@ public abstract class PlaybackActivity extends Activity
 	 *
 	 * @param songIntent intent containing song id as {@link Long} in its "id" extra.
 	 */
+	@SuppressLint("WrongConstant") // flag is ignored on Android < 7.0
 	protected void queryPluginsForIntent(Intent songIntent) {
 		// obtain list of plugins anew - some plugins may be installed/deleted
 		mPlugins.clear();
 		mLastRequestedCtx = songIntent;
 		Intent requestPlugins = new Intent(PluginUtils.ACTION_REQUEST_PLUGIN_PARAMS);
 		requestPlugins.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
+		requestPlugins.addFlags(0x01000000); // Intent.FLAG_RECEIVER_INCLUDE_BACKGROUND
 		sendBroadcast(requestPlugins);
 	}
 
@@ -793,7 +797,11 @@ public abstract class PlaybackActivity extends Activity
 							request.putExtra(PluginUtils.EXTRA_PARAM_SONG_TITLE, resolved.title);
 							request.putExtra(PluginUtils.EXTRA_PARAM_SONG_ARTIST, resolved.artist);
 							request.putExtra(PluginUtils.EXTRA_PARAM_SONG_ALBUM, resolved.album);
-							startService(request);
+							if (request.resolveActivity(getPackageManager()) != null) {
+								startActivity(request);
+							} else {
+								Log.e("PluginSystem", "Couldn't start plugin activity for " + request);
+							}
 						}
 
 						mLastRequestedCtx = null;

--- a/app/src/main/res/values/translatable.xml
+++ b/app/src/main/res/values/translatable.xml
@@ -381,6 +381,7 @@ THE SOFTWARE.
 	<string name="folder_neutral">Neutral</string>
 	<!-- Plugin system -->
 	<string name="plugins">Plugins</string>
+	<string name="plugin_needs_upgrade">Please upgrade plugin %s to the latest version</string>
 
 	<!-- Theme names -->
 	<string name="theme_name_standard_light">Standard</string>


### PR DESCRIPTION
In Android Oreo we can't use services without bringing them to the
foreground, i.e. showing icon and following specified lifecycle.

After some consideration the new way was implemented for plugin system.
Plugins will no longer have bound service and instead will do everything
required from within their activities. All background logic that
previously resided in services will now be performed before the activity
has even shown its window. This greatly reduces complexity and cost
associated with bringing service model in accordance with Oreo
guidelines. The only downside to this approach is small flickering
or pause in emulators as activities still expect to show themselves
on start instead of disappearing again.