### PR TITLE
Set STYLE_NO_TITLE for TrackDetailsDialog

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/TrackDetailsDialog.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/TrackDetailsDialog.java
@@ -69,6 +69,7 @@ public class TrackDetailsDialog extends DialogFragment {
 		super.onCreate(savedInstanceState);
 		mHandlerThread = new HandlerThread(getClass().getName());
 		mHandlerThread.start();
+		setStyle(DialogFragment.STYLE_NO_TITLE, 0);
 	}
 
 	@Override


### PR DESCRIPTION
This gets rid of the blank title section in the dialog when shown on the playlist activity and on older versions of Android.

This addresses https://github.com/vanilla-music/vanilla/pull/849#issuecomment-430756661