### PR TITLE
Add FOREGROUND_SERVICE permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@ THE SOFTWARE.
 	android:versionCode="10730"
 	android:installLocation="auto">
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<!-- This is needed for isWiredHeadsetOn() to work in some cases. (bug?) -->


### PR DESCRIPTION
Since 7c9731e05b4e5ebb92f5fe59519709606ba50ef9 targets API 28, playing a song will crash on Android 9 unless we declare this permission.

See https://developer.android.com/about/versions/pie/android-9.0-changes-28#fg-svc