### PR TITLE
Add a Jump to Time dialog

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackActivity.java
@@ -430,6 +430,7 @@ public abstract class PlaybackActivity extends Activity
 	static final int MENU_MORE_ARTIST = 23;
 	static final int MENU_MORE_GENRE = 24;
 	static final int MENU_MORE_FOLDER = 25;
+	static final int MENU_JUMP_TO_TIME = 26;
 
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu)

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -1737,7 +1737,19 @@ public final class PlaybackService extends Service
 		if (!mMediaPlayerInitialized)
 			return;
 		long position = (long)mMediaPlayer.getDuration() * progress / 1000;
-		mMediaPlayer.seekTo((int)position);
+		seekToPosition((int) position);
+	}
+
+	/**
+	 * Seeks to the given position in the current song.
+	 *
+	 * @param msec the offset in milliseconds from the start to seek to
+	 */
+	public void seekToPosition(int msec) {
+		if (!mMediaPlayerInitialized) {
+			return;
+		}
+		mMediaPlayer.seekTo(msec);
 		mHandler.sendEmptyMessage(MSG_BROADCAST_SEEK);
 	}
 

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/SlidingPlaybackActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/SlidingPlaybackActivity.java
@@ -127,6 +127,7 @@ public class SlidingPlaybackActivity extends PlaybackActivity
 		menu.add(0, MENU_CLEAR_QUEUE, 20, R.string.dequeue_rest);
 		menu.add(0, MENU_EMPTY_QUEUE, 20, R.string.empty_the_queue);
 		menu.add(0, MENU_SAVE_QUEUE, 20, R.string.save_as_playlist);
+		menu.add(0, MENU_JUMP_TO_TIME, 20, R.string.jump_to_time);
 		// This should only be required on ICS.
 		onSlideExpansionChanged(SlidingView.EXPANSION_PARTIAL);
 		return true;
@@ -146,6 +147,9 @@ public class SlidingPlaybackActivity extends PlaybackActivity
 		case MENU_SAVE_QUEUE:
 			PlaylistDialog dialog = PlaylistDialog.newInstance(this, null, null);
 			dialog.show(getFragmentManager(), "PlaylistDialog");
+			break;
+		case MENU_JUMP_TO_TIME:
+			JumpToTimeDialog.show(getFragmentManager());
 			break;
 		default:
 			return super.onOptionsItemSelected(item);
@@ -269,7 +273,7 @@ public class SlidingPlaybackActivity extends PlaybackActivity
 	/**
 	 * Update seek bar progress and schedule another update in one second
 	 */
-	private void updateElapsedTime() {
+	public void updateElapsedTime() {
 		long position = PlaybackService.hasInstance() ? PlaybackService.get(this).getPosition() : 0;
 
 		if (!mSeekBarTracking) {

--- a/app/src/main/res/layout/duration_input.xml
+++ b/app/src/main/res/layout/duration_input.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2018 Toby Hsieh
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<LinearLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:orientation="horizontal"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:gravity="center_horizontal">
+
+	<EditText
+		android:id="@+id/hours"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:inputType="number"
+		android:maxLength="2"
+		android:hint="@string/hour_hint" />
+
+	<TextView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:text="@string/time_separator"/>
+
+	<EditText
+		android:id="@+id/minutes"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:inputType="number"
+		android:maxLength="2"
+		android:hint="@string/minute_hint" />
+
+	<TextView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:text="@string/time_separator"/>
+
+	<EditText
+		android:id="@+id/seconds"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:inputType="number"
+		android:maxLength="2"
+		android:hint="@string/second_hint" />
+
+</LinearLayout>

--- a/app/src/main/res/values/translatable.xml
+++ b/app/src/main/res/values/translatable.xml
@@ -329,6 +329,13 @@ THE SOFTWARE.
 	<string name="preferences_action_enqueue_current_artist">Enqueue artist</string>
 	<string name="preferences_action_enqueue_current_genre">Enqueue genre</string>
 
+	<string name="jump_to_time">Jump to Time</string>
+	<string name="time_separator">:</string>
+	<string name="hour_hint">HH</string>
+	<string name="minute_hint">MM</string>
+	<string name="second_hint">SS</string>
+	<string name="error_invalid_position">Invalid position</string>
+
 	<string name="filebrowser_start">Filebrowser home</string>
 	<string name="customize_filebrowser_start">Filebrowser starts at this directory</string>
 	<string name="select">Select</string>


### PR DESCRIPTION
This implements #827 by adding a context menu entry to open a dialog that allows the user to input a time/position to seek to for the current song.

Screenshot:
<img width="315" alt="jump_to_time" src="https://user-images.githubusercontent.com/1714479/48329088-f254dd00-e5fb-11e8-8662-955124357b24.png">
