### PR TITLE
[Fix #879] Implement refreshing cover cache and details for changed song

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaScanner.java
+++ b/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaScanner.java
@@ -330,7 +330,7 @@ public class MediaScanner implements Handler.Callback {
 	}
 
 	/**
-	 * Checks the state of the native media db to deceide if we are going to
+	 * Checks the state of the native media db to decide if we are going to
 	 * check for deleted or new/modified items
 	 */
 	private void guessQuickScanPlan() {
@@ -620,6 +620,9 @@ public class MediaScanner implements Handler.Callback {
 					mBackend.insert(MediaLibrary.TABLE_GENRES_SONGS, null, v);
 				}
 			}
+
+			// song was changed in database, send notification to listeners
+			MediaLibrary.notifyObserver(LibraryObserver.Type.SONG, songId, true);
 		} // end if (mustInsert)
 
 		Log.v("VanillaMusic", "MediaScanner: inserted "+path);

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
@@ -942,9 +942,9 @@ public class LibraryActivity
 	}
 
 	@Override
-	protected void onSongChange(Song song)
+	protected void onSongChange(Song song, boolean force)
 	{
-		super.onSongChange(song);
+		super.onSongChange(song, force);
 
 		mBottomBarControls.setSong(song);
 		if (song != null) {

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackActivity.java
@@ -327,11 +327,12 @@ public abstract class PlaybackActivity extends Activity
 	 * Called when the current song changes.
 	 *
 	 * @param song The new song
+	 * @param force force invalidation of dependent views
 	 */
-	protected void onSongChange(Song song)
+	protected void onSongChange(Song song, boolean force)
 	{
 		if (mCoverView != null)
-			mCoverView.querySongs();
+			mCoverView.querySongs(force);
 	}
 
 	protected void setSong(final Song song)
@@ -341,7 +342,7 @@ public abstract class PlaybackActivity extends Activity
 			@Override
 			public void run()
 			{
-				onSongChange(song);
+				onSongChange(song, false);
 			}
 		});
 	}

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/SlidingPlaybackActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/SlidingPlaybackActivity.java
@@ -102,10 +102,10 @@ public class SlidingPlaybackActivity extends PlaybackActivity
 	}
 
 	@Override
-	protected void onSongChange(Song song) {
+	protected void onSongChange(Song song, boolean force) {
 		setDuration(song == null ? 0 : song.duration);
 		updateElapsedTime();
-		super.onSongChange(song);
+		super.onSongChange(song, force);
 	}
 
 	@Override

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/SongTimeline.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/SongTimeline.java
@@ -23,12 +23,12 @@
 
 package ch.blinkenlights.android.vanilla;
 
+import android.support.annotation.Nullable;
 import ch.blinkenlights.android.medialibrary.MediaLibrary;
 
 import android.content.Context;
 import android.database.Cursor;
-import android.net.Uri;
-import android.provider.MediaStore;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -662,7 +662,7 @@ public final class SongTimeline {
 
 	/**
 	 * Returns 'Song' at given position in queue
-	*/
+	 */
 	public Song getSongByQueuePosition(int pos) {
 		Song song = null;
 		synchronized (this) {
@@ -673,7 +673,7 @@ public final class SongTimeline {
 	}
 
 	/**
-	 * Returns song position for given {@link Song.id}
+	 * Returns song position for given {@link Song#id}
 	 */
 	public int getQueuePositionForSongId(long id) {
 		synchronized (this) {
@@ -684,6 +684,20 @@ public final class SongTimeline {
 			}
 		}
 		return -1;
+	}
+
+	/**
+	 * Returns song object for given {@link Song#id}
+	 */
+	@Nullable
+	public Song getSongById(long id) {
+		synchronized (this) {
+			for (Song current: mSongs) {
+				if (current.id == id)
+					return current;
+			}
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Previously changes in media files on disk only caused changes in
song database that were never picked by cover cache or full playback
activity.

This commit fixes this behaviour. It adds a link between updating
a song after scan in database to corresponding song refresh in song
timeline and an eviction for refreshed song from cover cache.

It also registers full playback activity as a listener for scan
completion so it updates cover views and song info.