### PR TITLE
Speedup plugin search, add quick plugin button, fixes #859

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/FullPlaybackActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/FullPlaybackActivity.java
@@ -302,10 +302,14 @@ public class FullPlaybackActivity extends SlidingPlaybackActivity
 		menu.add(0, MENU_SHARE, 30, R.string.share);
 
 		if (PluginUtils.checkPlugins(this)) {
-			menu.add(0, MENU_PLUGINS, 30, R.string.plugins);
+			menu.add(0, MENU_PLUGINS, 30, R.string.plugins)
+				.setIcon(R.drawable.plugin)
+				.setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_IF_ROOM);
 		}
 
-		mFavorites = menu.add(0, MENU_SONG_FAVORITE, 0, R.string.add_to_favorites).setIcon(R.drawable.btn_rating_star_off_mtrl_alpha).setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_IF_ROOM);
+		mFavorites = menu.add(0, MENU_SONG_FAVORITE, 0, R.string.add_to_favorites)
+			.setIcon(R.drawable.btn_rating_star_off_mtrl_alpha)
+			.setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_IF_ROOM);
 
 		// Subitems of 'enqueue...'
 		enqueueMenu.add(0, MENU_ENQUEUE_ALBUM, 30, R.string.album);

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PluginUtils.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PluginUtils.java
@@ -37,7 +37,6 @@ public class PluginUtils {
     // these actions are for passing between main player and plugins
     public static final String ACTION_REQUEST_PLUGIN_PARAMS = "ch.blinkenlights.android.vanilla.action.REQUEST_PLUGIN_PARAMS"; // broadcast
     public static final String ACTION_HANDLE_PLUGIN_PARAMS = "ch.blinkenlights.android.vanilla.action.HANDLE_PLUGIN_PARAMS"; // answer
-    public static final String ACTION_WAKE_PLUGIN = "ch.blinkenlights.android.vanilla.action.WAKE_PLUGIN"; // targeted at each found
     public static final String ACTION_LAUNCH_PLUGIN = "ch.blinkenlights.android.vanilla.action.LAUNCH_PLUGIN"; // targeted at selected by user
 
     // these are used by plugins to describe themselves
@@ -56,28 +55,6 @@ public class PluginUtils {
     public static boolean checkPlugins(Context ctx) {
         PackageManager pm = ctx.getPackageManager();
         List<ResolveInfo> resolved = pm.queryBroadcastReceivers(new Intent(ACTION_REQUEST_PLUGIN_PARAMS), 0);
-        if (!resolved.isEmpty()) {
-            // If plugin is just installed, Android will not deliver intents
-            // to its receiver until it's started at least one time
-            boolean hasPlugins = false;
-            for (ResolveInfo ri : resolved) {
-                Intent awaker = new Intent(ACTION_WAKE_PLUGIN);
-                awaker.setPackage(ri.activityInfo.packageName);
-
-                // all plugins must have respective activity that can handle ACTION_WAKE_PLUGIN
-                if (awaker.resolveActivity(pm) != null) {
-                    hasPlugins = true;
-                    ctx.startActivity(awaker);
-                } else {
-                    // need to upgrade the plugin from service-based plugin system to activity-based
-                    CharSequence pluginName = ri.loadLabel(pm);
-                    String error = String.format(ctx.getString(R.string.plugin_needs_upgrade), pluginName);
-                    Toast.makeText(ctx, error, Toast.LENGTH_SHORT).show();
-                }
-            }
-            return hasPlugins;
-        }
-
-        return false;
+        return !resolved.isEmpty();
     }
 }

--- a/app/src/main/res/drawable/plugin.xml
+++ b/app/src/main/res/drawable/plugin.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M20.5,11H19V7c0,-1.1 -0.9,-2 -2,-2h-4V3.5C13,2.12 11.88,1 10.5,1S8,2.12 8,3.5V5H4c-1.1,0 -1.99,0.9 -1.99,2v3.8H3.5c1.49,0 2.7,1.21 2.7,2.7s-1.21,2.7 -2.7,2.7H2V20c0,1.1 0.9,2 2,2h3.8v-1.5c0,-1.49 1.21,-2.7 2.7,-2.7 1.49,0 2.7,1.21 2.7,2.7V22H17c1.1,0 2,-0.9 2,-2v-4h1.5c1.38,0 2.5,-1.12 2.5,-2.5S21.88,11 20.5,11z"/>
+</vector>


### PR DESCRIPTION
We are now fully switched to activity-based plugin
start system, so we don't need to start service or
wake activity anymore. Delete relevant part.

If the additiona; information is needed about the
plugin we can dig it out from its broadcast receiver.

Also, add quick "Plugins" button to the full playback
activity so there are only 2 clicks away from any plugin.