### PR TITLE
[Issue #905] Add playlist path relativization option.

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/FileSystemAdapter.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/FileSystemAdapter.java
@@ -25,21 +25,17 @@ package ch.blinkenlights.android.vanilla;
 
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.drawable.Drawable;
 import android.os.FileObserver;
-import android.util.Log;
-import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import java.io.File;
 import java.io.FilenameFilter;
-import java.io.IOException;
-import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.regex.Pattern;
 
 /**
@@ -54,10 +50,6 @@ public class FileSystemAdapter
 	private static final Pattern FILE_SEPARATOR = Pattern.compile(File.separator);
 	private static final Pattern GUESS_MUSIC = Pattern.compile("^(.+\\.(mp3|ogg|mka|opus|flac|aac|m4a|wav))$", Pattern.CASE_INSENSITIVE);
 	private static final Pattern GUESS_IMAGE = Pattern.compile("^(.+\\.(gif|jpe?g|png|bmp|tiff?))$", Pattern.CASE_INSENSITIVE);
-	/**
-	 * The string (but also valid path!) to use to indicate the parent directory
-	 */
-	private static final String NAME_PARENT_FOLDER = "..";
 	/**
 	 * The root directory of the device
 	 */
@@ -206,7 +198,7 @@ public class FileSystemAdapter
 		ArrayList<File> files = new ArrayList<File>(Arrays.asList(readdir));
 		Collections.sort(files, mFileComparator);
 		if (!mFsRoot.equals(file))
-			files.add(0, new File(file, NAME_PARENT_FOLDER));
+			files.add(0, new File(file, FileUtils.NAME_PARENT_FOLDER));
 
 		return files.toArray(new File[files.size()]);
 	}
@@ -337,7 +329,7 @@ public class FileSystemAdapter
 	 * @return true if given file points to the parent folder
 	 */
 	private static boolean pointsToParentFolder(File file) {
-		return NAME_PARENT_FOLDER.equals(file.getName());
+		return FileUtils.NAME_PARENT_FOLDER.equals(file.getName());
 	}
 
 	/**

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/FileUtils.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/FileUtils.java
@@ -91,19 +91,19 @@ public class FileUtils {
 	}
 
 	/**
-	 * Attempts to generate a relative path from a source File to a destination.
+	 * Attempts to generate a relative path from a base, to a destination.
 	 * Will attempt to perform directory traversal to find a common path.
 	 * Upon failure to relativize, returns the original destination.
 	 *
-	 * @param source The File the path is relative to e.g. /a/b/c/
-	 * @param destination The File the path is pointing to e.g. /a/b/c/d.mp3
+	 * @param base The File the path is relative to e.g. /a/b/c/
+	 * @param destination The File the resultant path should point to e.g. /a/b/c/d.mp3
 	 * @return A relative or absolute path pointing to the destination.
 	 */
-	public static String relativize(File source, File destination) {
-		if (destination.isAbsolute() != source.isAbsolute())
+	public static String relativize(File base, File destination) {
+		if (destination.isAbsolute() != base.isAbsolute())
 			return destination.getPath();
 
-		File commonParentFile = source;
+		File commonParentFile = base;
 		final String destinationPath = destination.getPath();
 		int traversalCount = 0;
 
@@ -131,23 +131,19 @@ public class FileUtils {
 	 * Attempts to resolve a path from a base, if the destination is relative.
 	 * Upon failure to resolve, returns the original destination.
 	 *
-	 * @param source The File the path may be relative to e.g. /a/b/c/
-	 * @param destination The File the path is pointing to e.g. /a/b/c/d.mp3
+	 * @param base The File the path may be relative to e.g. /a/b/c/
+	 * @param destination The File the resultant path should point to e.g. d.mp3
 	 * @return A relative or absolute path pointing to the destination.
 	 */
-	public static String resolve(File source, File destination) {
-		String path;
+	public static String resolve(File base, File destination) {
+		String path = destination.getPath();
 
 		try {
-			if (destination.isAbsolute()) {
-				path = destination.getPath();
-			} else {
-				path = new File(source,
-						destination.getPath())
-					.getAbsolutePath();
+			if (!destination.isAbsolute()) {
+				path = new File(base, path).getAbsolutePath();
 			}
 		} catch (SecurityException ex) {
-			path = destination.getPath();
+			// Ignore.
 		}
 		return path;
 	}
@@ -165,7 +161,7 @@ public class FileUtils {
 		int type = intent.getIntExtra(LibraryAdapter.DATA_TYPE, MediaUtils.TYPE_INVALID);
 		boolean isFolder = intent.getBooleanExtra(LibraryAdapter.DATA_EXPANDABLE, false);
 		String path = intent.getStringExtra(LibraryAdapter.DATA_FILE);
-		if (type == MediaUtils.TYPE_FILE && isFolder == false) {
+		if (type == MediaUtils.TYPE_FILE && !isFolder) {
 			try {
 				URI uri = new URI("file", path, null);
 				String mimeGuess = URLConnection.guessContentTypeFromName(uri.toString());

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/MediaUtils.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/MediaUtils.java
@@ -36,8 +36,6 @@ import java.util.Random;
 
 import android.util.Log;
 
-import junit.framework.Assert;
-
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
@@ -46,9 +44,7 @@ import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.support.v4.content.FileProvider;
-import android.text.TextUtils;
 import android.database.MatrixCursor;
-import android.util.Log;
 import android.widget.Toast;
 
 

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -507,8 +507,9 @@ public final class PlaybackService extends Service
 		mRemoteControlClient.initializeRemote();
 
 		int syncMode = Integer.parseInt(settings.getString(PrefKeys.PLAYLIST_SYNC_MODE, PrefDefaults.PLAYLIST_SYNC_MODE));
+		boolean syncRelativePaths = settings.getBoolean(PrefKeys.PLAYLIST_SYNC_RELATIVE_PATHS, PrefDefaults.PLAYLIST_SYNC_RELATIVE_PATHS);
 		String syncFolder = settings.getString(PrefKeys.PLAYLIST_SYNC_FOLDER, PrefDefaults.PLAYLIST_SYNC_FOLDER);
-		mPlaylistObserver = new PlaylistObserver(this, syncFolder, syncMode);
+		mPlaylistObserver = new PlaylistObserver(this, syncFolder, syncMode, syncRelativePaths);
 
 		mLooper = thread.getLooper();
 		mHandler = new Handler(mLooper, this);
@@ -942,12 +943,13 @@ public final class PlaybackService extends Service
 			mReadaheadEnabled = settings.getBoolean(PrefKeys.ENABLE_READAHEAD, PrefDefaults.ENABLE_READAHEAD);
 		} else if (PrefKeys.AUTOPLAYLIST_PLAYCOUNTS.equals(key)) {
 			mAutoPlPlaycounts = settings.getInt(PrefKeys.AUTOPLAYLIST_PLAYCOUNTS, PrefDefaults.AUTOPLAYLIST_PLAYCOUNTS);
-		} else if (PrefKeys.PLAYLIST_SYNC_MODE.equals(key) || PrefKeys.PLAYLIST_SYNC_FOLDER.equals(key)) {
+		} else if (PrefKeys.PLAYLIST_SYNC_MODE.equals(key) || PrefKeys.PLAYLIST_SYNC_FOLDER.equals(key) || PrefKeys.PLAYLIST_SYNC_RELATIVE_PATHS.equals(key)) {
 			int syncMode = Integer.parseInt(settings.getString(PrefKeys.PLAYLIST_SYNC_MODE, PrefDefaults.PLAYLIST_SYNC_MODE));
+			boolean syncRelativePaths = settings.getBoolean(PrefKeys.PLAYLIST_SYNC_RELATIVE_PATHS, PrefDefaults.PLAYLIST_SYNC_RELATIVE_PATHS);
 			String syncFolder = settings.getString(PrefKeys.PLAYLIST_SYNC_FOLDER, PrefDefaults.PLAYLIST_SYNC_FOLDER);
 
 			mPlaylistObserver.unregister();
-			mPlaylistObserver = new PlaylistObserver(this, syncFolder, syncMode);
+			mPlaylistObserver = new PlaylistObserver(this, syncFolder, syncMode, syncRelativePaths);
 		} else if (PrefKeys.SELECTED_THEME.equals(key) || PrefKeys.DISPLAY_MODE.equals(key)) {
 			// Theme changed: trigger a restart of all registered activites
 			ArrayList<TimelineCallback> list = sCallbacks;

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -507,9 +507,9 @@ public final class PlaybackService extends Service
 		mRemoteControlClient.initializeRemote();
 
 		int syncMode = Integer.parseInt(settings.getString(PrefKeys.PLAYLIST_SYNC_MODE, PrefDefaults.PLAYLIST_SYNC_MODE));
-		boolean syncRelativePaths = settings.getBoolean(PrefKeys.PLAYLIST_SYNC_RELATIVE_PATHS, PrefDefaults.PLAYLIST_SYNC_RELATIVE_PATHS);
+		boolean exportRelativePaths = settings.getBoolean(PrefKeys.PLAYLIST_EXPORT_RELATIVE_PATHS, PrefDefaults.PLAYLIST_EXPORT_RELATIVE_PATHS);
 		String syncFolder = settings.getString(PrefKeys.PLAYLIST_SYNC_FOLDER, PrefDefaults.PLAYLIST_SYNC_FOLDER);
-		mPlaylistObserver = new PlaylistObserver(this, syncFolder, syncMode, syncRelativePaths);
+		mPlaylistObserver = new PlaylistObserver(this, syncFolder, syncMode, exportRelativePaths);
 
 		mLooper = thread.getLooper();
 		mHandler = new Handler(mLooper, this);
@@ -943,13 +943,13 @@ public final class PlaybackService extends Service
 			mReadaheadEnabled = settings.getBoolean(PrefKeys.ENABLE_READAHEAD, PrefDefaults.ENABLE_READAHEAD);
 		} else if (PrefKeys.AUTOPLAYLIST_PLAYCOUNTS.equals(key)) {
 			mAutoPlPlaycounts = settings.getInt(PrefKeys.AUTOPLAYLIST_PLAYCOUNTS, PrefDefaults.AUTOPLAYLIST_PLAYCOUNTS);
-		} else if (PrefKeys.PLAYLIST_SYNC_MODE.equals(key) || PrefKeys.PLAYLIST_SYNC_FOLDER.equals(key) || PrefKeys.PLAYLIST_SYNC_RELATIVE_PATHS.equals(key)) {
+		} else if (PrefKeys.PLAYLIST_SYNC_MODE.equals(key) || PrefKeys.PLAYLIST_SYNC_FOLDER.equals(key) || PrefKeys.PLAYLIST_EXPORT_RELATIVE_PATHS.equals(key)) {
 			int syncMode = Integer.parseInt(settings.getString(PrefKeys.PLAYLIST_SYNC_MODE, PrefDefaults.PLAYLIST_SYNC_MODE));
-			boolean syncRelativePaths = settings.getBoolean(PrefKeys.PLAYLIST_SYNC_RELATIVE_PATHS, PrefDefaults.PLAYLIST_SYNC_RELATIVE_PATHS);
+			boolean exportRelativePaths = settings.getBoolean(PrefKeys.PLAYLIST_EXPORT_RELATIVE_PATHS, PrefDefaults.PLAYLIST_EXPORT_RELATIVE_PATHS);
 			String syncFolder = settings.getString(PrefKeys.PLAYLIST_SYNC_FOLDER, PrefDefaults.PLAYLIST_SYNC_FOLDER);
 
 			mPlaylistObserver.unregister();
-			mPlaylistObserver = new PlaylistObserver(this, syncFolder, syncMode, syncRelativePaths);
+			mPlaylistObserver = new PlaylistObserver(this, syncFolder, syncMode, exportRelativePaths);
 		} else if (PrefKeys.SELECTED_THEME.equals(key) || PrefKeys.DISPLAY_MODE.equals(key)) {
 			// Theme changed: trigger a restart of all registered activites
 			ArrayList<TimelineCallback> list = sCallbacks;

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaylistObserver.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaylistObserver.java
@@ -26,7 +26,6 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.Build;
-import android.os.Environment;
 import android.os.FileObserver;
 import android.os.Handler;
 import android.os.HandlerThread;
@@ -50,21 +49,25 @@ public class PlaylistObserver extends SQLiteOpenHelper implements Handler.Callba
 	/**
 	 * Whether or not to write debug logs.
 	 */
-	private final static boolean DEBUG = false;
+	private static final boolean DEBUG = false;
 	/**
 	 * Bits for mSyncMode
 	 */
-	public final static int SYNC_MODE_IMPORT = (1 << 0);
-	public final static int SYNC_MODE_EXPORT = (1 << 1);
-	public final static int SYNC_MODE_PURGE  = (1 << 2);
+	public static final int SYNC_MODE_IMPORT = (1 << 0);
+	public static final int SYNC_MODE_EXPORT = (1 << 1);
+	public static final int SYNC_MODE_PURGE  = (1 << 2);
 	/**
 	 * Timeout to coalesce duplicate messages, ~2.3 sec because no real reason.
 	 */
-	private final static int COALESCE_EVENTS_DELAY_MS = 2345;
+	private static final int COALESCE_EVENTS_DELAY_MS = 2345;
 	/**
 	 * Extension to use for M3U files
 	 */
-	private final static String M3U_EXT = ".m3u";
+	private static final String M3U_EXT = ".m3u";
+	/**
+	 * Line comment prefix for M3U files
+	 */
+	private static final String M3U_LINE_COMMENT_PREFIX = "#";
 	/**
 	 * Context to use.
 	 */
@@ -90,14 +93,18 @@ public class PlaylistObserver extends SQLiteOpenHelper implements Handler.Callba
 	 */
 	private int mSyncMode;
 	/**
+	 * Whether to export playlists using relative file paths.
+	 */
+	private boolean mSyncRelativePaths;
+	/**
 	 * Database fields
 	 */
 	private static class Database {
-		final static String TABLE_NAME = "playlist_metadata";
-		final static String _ID = "_id";
-		final static String NAME = "name";
-		final static String HASH = "hash";
-		final static String[] FILLED_PROJECTION = {
+		static final String TABLE_NAME = "playlist_metadata";
+		static final String _ID = "_id";
+		static final String NAME = "name";
+		static final String HASH = "hash";
+		static final String[] FILLED_PROJECTION = {
 			_ID,
 			NAME,
 			HASH,
@@ -105,11 +112,12 @@ public class PlaylistObserver extends SQLiteOpenHelper implements Handler.Callba
 	}
 
 
-	public PlaylistObserver(Context context, String folder, int mode) {
+	public PlaylistObserver(Context context, String folder, int mode, boolean syncRelativePaths) {
 		super(context, "playlist_observer.db", null, 1 /* version */);
 		mContext = context;
 		mSyncMode = mode;
 		mPlaylists = new File(folder);
+		mSyncRelativePaths = syncRelativePaths;
 
 		// Launch new thread for background execution
 		mHandlerThread= new HandlerThread("PlaylisObserverHandler", Process.THREAD_PRIORITY_LOWEST);
@@ -198,11 +206,11 @@ public class PlaylistObserver extends SQLiteOpenHelper implements Handler.Callba
 	 * Message handler, used to dedupe messages and perform
 	 * background work.
 	 */
-	private final static int MSG_DUMP_M3U = 1;
-	private final static int MSG_DUMP_ALL_M3U = 2;
-	private final static int MSG_IMPORT_M3U = 3;
-	private final static int MSG_FORCE_M3U_IMPORT = 4;
-	private final static int MSG_FULL_SYNC_SCAN = 5;
+	private static final int MSG_DUMP_M3U = 1;
+	private static final int MSG_DUMP_ALL_M3U = 2;
+	private static final int MSG_IMPORT_M3U = 3;
+	private static final int MSG_FORCE_M3U_IMPORT = 4;
+	private static final int MSG_FULL_SYNC_SCAN = 5;
 	ArrayList<Integer> msgDedupe = new ArrayList<>();
 	@Override
 	public boolean handleMessage(Message message) {
@@ -332,8 +340,13 @@ public class PlaylistObserver extends SQLiteOpenHelper implements Handler.Callba
 			try (BufferedReader br = new BufferedReader(new FileReader(m3u))) {
 				String line;
 				while ((line = br.readLine()) != null) {
-					if (line.matches("^/.+")) {
-						Playlist.addToPlaylist(mContext, import_id, MediaUtils.buildFileQuery(line, Song.FILLED_PROJECTION,  false /* recursive */));
+					if (!(line.isEmpty() || line.startsWith(M3U_LINE_COMMENT_PREFIX))) {
+						// Handle relative paths and Windows directory separators.
+						final String mediaPath = FileUtils.resolve(mPlaylists,
+							new File(FileUtils.normalizeDirectorySeparators(line)));
+						Playlist.addToPlaylist(mContext,
+							import_id,
+							MediaUtils.buildFileQuery(mediaPath, Song.FILLED_PROJECTION,  false /* recursive */));
 					}
 				}
 				updatePlaylistMetadata(import_id, import_as, hash);
@@ -371,7 +384,14 @@ public class PlaylistObserver extends SQLiteOpenHelper implements Handler.Callba
 			if (cursor != null) {
 				pw = new PrintWriter(m3u);
 				while (cursor.moveToNext()) {
-					final String path = cursor.getString(1);
+					// Write paths relative to the playlist export directory, if enabled.
+					final String path;
+					if (mSyncRelativePaths) {
+						path = FileUtils.relativize(mPlaylists,
+							new File(cursor.getString(1)));
+					} else {
+						path = cursor.getString(1);
+					}
 					pw.println(path);
 				}
 				pw.flush();
@@ -605,6 +625,12 @@ public class PlaylistObserver extends SQLiteOpenHelper implements Handler.Callba
 		return new FileObserver(target.getAbsolutePath(), mask) {
 			@Override
 			public void onEvent(int event, String dirent) {
+				// Events such as IN_IGNORED pass dirent = null.
+				if (dirent == null) {
+					XT("FileObserver::onEvent dirent=null with event " + event);
+					return;
+				}
+
 				if (!isM3uFilename(dirent))
 					return;
 

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PrefDefaults.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PrefDefaults.java
@@ -77,7 +77,7 @@ public class PrefDefaults {
 	public static final boolean QUEUE_ENABLE_SCROLL_TO_SONG = false;
 	public static final boolean KEEP_SCREEN_ON = false;
 	public static final String  PLAYLIST_SYNC_MODE = "0";
-	public static final boolean PLAYLIST_SYNC_RELATIVE_PATHS = false;
 	public static final String  PLAYLIST_SYNC_FOLDER = "/sdcard/Playlists";
+	public static final boolean PLAYLIST_EXPORT_RELATIVE_PATHS = false;
 	public static final boolean JUMP_TO_ENQUEUED_ON_PLAY = true;
 }

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PrefDefaults.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PrefDefaults.java
@@ -26,6 +26,10 @@ package ch.blinkenlights.android.vanilla;
  * SharedPreference default values. Must be kept in sync with keys in res/xml/prefs_*.xml.
  */
 public class PrefDefaults {
+	private PrefDefaults() {
+		// Private constructor to hide implicit one.
+	}
+
 	public static final Action  COVER_LONGPRESS_ACTION = Action.PlayPause;
 	public static final Action  COVER_PRESS_ACTION = Action.ToggleControls;
 	public static final String  DEFAULT_ACTION_INT = "9";
@@ -73,6 +77,7 @@ public class PrefDefaults {
 	public static final boolean QUEUE_ENABLE_SCROLL_TO_SONG = false;
 	public static final boolean KEEP_SCREEN_ON = false;
 	public static final String  PLAYLIST_SYNC_MODE = "0";
+	public static final boolean PLAYLIST_SYNC_RELATIVE_PATHS = false;
 	public static final String  PLAYLIST_SYNC_FOLDER = "/sdcard/Playlists";
 	public static final boolean JUMP_TO_ENQUEUED_ON_PLAY = true;
 }

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PrefKeys.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PrefKeys.java
@@ -27,6 +27,10 @@ package ch.blinkenlights.android.vanilla;
  * SharedPreference keys. Must be kept in sync with {@link PrefDefaults}.
  */
 public class PrefKeys {
+	private PrefKeys() {
+		// Private constructor to hide implicit one.
+	}
+
 	public static final String COVER_LONGPRESS_ACTION = "cover_longpress_action";
 	public static final String COVER_PRESS_ACTION = "cover_press_action";
 	public static final String DEFAULT_ACTION_INT = "default_action_int";
@@ -74,6 +78,7 @@ public class PrefKeys {
 	public static final String QUEUE_ENABLE_SCROLL_TO_SONG = "queue_enable_scroll_to_song";
 	public static final String KEEP_SCREEN_ON = "keep_screen_on";
 	public static final String PLAYLIST_SYNC_MODE = "playlist_sync_mode";
+	public static final String PLAYLIST_SYNC_RELATIVE_PATHS = "playlist_sync_relative_paths";
 	public static final String PLAYLIST_SYNC_FOLDER = "playlist_sync_folder";
 	public static final String JUMP_TO_ENQUEUED_ON_PLAY = "jump_to_enqueued_on_play";
 }

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PrefKeys.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PrefKeys.java
@@ -78,7 +78,7 @@ public class PrefKeys {
 	public static final String QUEUE_ENABLE_SCROLL_TO_SONG = "queue_enable_scroll_to_song";
 	public static final String KEEP_SCREEN_ON = "keep_screen_on";
 	public static final String PLAYLIST_SYNC_MODE = "playlist_sync_mode";
-	public static final String PLAYLIST_SYNC_RELATIVE_PATHS = "playlist_sync_relative_paths";
 	public static final String PLAYLIST_SYNC_FOLDER = "playlist_sync_folder";
+	public static final String PLAYLIST_EXPORT_RELATIVE_PATHS = "playlist_export_relative_paths";
 	public static final String JUMP_TO_ENQUEUED_ON_PLAY = "jump_to_enqueued_on_play";
 }

--- a/app/src/main/res/values/translatable.xml
+++ b/app/src/main/res/values/translatable.xml
@@ -358,8 +358,8 @@ THE SOFTWARE.
 	<string name="playlist_sync_disabled">Disabled</string>
 	<string name="playlist_sync_folder_title">Synchronization folder</string>
 	<string name="playlist_sync_folder_summary">Folder to use for playlist synchronization</string>
-	<string name="playlist_sync_relative_paths_title">Export using relative paths</string>
-	<string name="playlist_sync_relative_paths_summary">Reference file paths relative to the playlist</string>
+	<string name="playlist_export_relative_paths_title">Export using relative paths</string>
+	<string name="playlist_export_relative_paths_summary">Reference file paths relative to the playlist</string>
 
 	<string name="permission_request_summary">Vanilla Music needs read permission to display your music library</string>
 	<string name="reverse_sort">Reverse sort</string>

--- a/app/src/main/res/values/translatable.xml
+++ b/app/src/main/res/values/translatable.xml
@@ -358,6 +358,8 @@ THE SOFTWARE.
 	<string name="playlist_sync_disabled">Disabled</string>
 	<string name="playlist_sync_folder_title">Synchronization folder</string>
 	<string name="playlist_sync_folder_summary">Folder to use for playlist synchronization</string>
+	<string name="playlist_sync_relative_paths_title">Export using relative paths</string>
+	<string name="playlist_sync_relative_paths_summary">Reference file paths relative to the playlist</string>
 
 	<string name="permission_request_summary">Vanilla Music needs read permission to display your music library</string>
 	<string name="reverse_sort">Reverse sort</string>

--- a/app/src/main/res/xml/preference_playlist.xml
+++ b/app/src/main/res/xml/preference_playlist.xml
@@ -49,4 +49,10 @@ THE SOFTWARE.
 			android:targetPackage="ch.blinkenlights.android.vanilla"
 			android:targetClass="ch.blinkenlights.android.vanilla.PlaylistObserverDirActivity" />
 	</PreferenceScreen>
+	<CheckBoxPreference
+		android:defaultValue="false"
+		android:dependency="playlist_sync_mode"
+		android:key="playlist_sync_relative_paths"
+		android:summary="@string/playlist_sync_relative_paths_summary"
+		android:title="@string/playlist_sync_relative_paths_title" />
 </PreferenceScreen>

--- a/app/src/main/res/xml/preference_playlist.xml
+++ b/app/src/main/res/xml/preference_playlist.xml
@@ -52,7 +52,7 @@ THE SOFTWARE.
 	<CheckBoxPreference
 		android:defaultValue="false"
 		android:dependency="playlist_sync_mode"
-		android:key="playlist_sync_relative_paths"
-		android:summary="@string/playlist_sync_relative_paths_summary"
-		android:title="@string/playlist_sync_relative_paths_title" />
+		android:key="playlist_export_relative_paths"
+		android:summary="@string/playlist_export_relative_paths_summary"
+		android:title="@string/playlist_export_relative_paths_title" />
 </PreferenceScreen>


### PR DESCRIPTION
This change adds a new option within the playlists settings item to relativize file paths from the playlists directory e.g.
- Music file: /storage/emulated/0/Music/Song.mp3
- Playlist directory: /storage/emulated/0/Playlists/
- Resultant path: ../Music/Song.mp3

The path relativization solution is not completely general, since it will incorrectly relativize UNC paths on Windows and is not aware of the filesystem's case insensitivity (case insensitivity may be an issue for FAT32).

This should resolve #905.