### PR TITLE
Remove onOptionsItemSelected to fix backbutton in settings

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PreferencesActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PreferencesActivity.java
@@ -91,17 +91,6 @@ public class PreferencesActivity extends PreferenceActivity
 	}
 
 	@Override
-	public boolean onOptionsItemSelected(MenuItem item)
-	{
-		if (item.getItemId() == android.R.id.home) {
-			finish();
-			return true;
-		} else {
-			return super.onOptionsItemSelected(item);
-		}
-	}
-
-	@Override
 	public void onSharedPreferenceChanged (SharedPreferences sharedPreferences, String key) {
 		if (PrefKeys.SELECTED_THEME.equals(key)) {
 			// this gets called by all preference instances: we force them to redraw


### PR DESCRIPTION
Fixes #918 
This error occurs because the onClickOptionsMenu always returns to the library and overrides the default behavior. The default would be to use the appstack to decide which was the last activity and to return to that.