### PR TITLE
Added persistence to seektime for playing songs

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaLibrary.java
+++ b/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaLibrary.java
@@ -383,6 +383,45 @@ public class MediaLibrary  {
 	}
 
 	/**
+	 * Updates the timestamp of a played song
+	 *
+	 * @param context the context to use
+	 * @param id the song id to update
+	 * @param timestamp the timestamp
+	 */
+	public static void updateSongTimestamp(Context context, long id, int timestamp) {
+		String selection = MediaLibrary.SongColumns._ID+"="+id;
+		getBackend(context).execSQL("UPDATE "+MediaLibrary.TABLE_SONGS+" SET "+SongColumns.TIMESTAMP_LAST_PLAY+"="+timestamp+" WHERE "+selection);
+	}
+
+	/**
+	 * Updates the timestamp of a played song
+	 *
+	 * @param context the context to use
+	 * @param id the song id to update
+	 * @return the timestamp
+	 */
+	public static int getSongTimestamp(Context context, long id) {
+
+		String[] projection = {SongColumns._ID, SongColumns.TIMESTAMP_LAST_PLAY};
+		String selection = SongColumns._ID + " = ?";
+		String[] selectionArgs = { String.valueOf(id) };
+
+		Cursor cursor = MediaLibrary.queryLibrary(context, MediaLibrary.TABLE_SONGS, projection, selection, selectionArgs, null);
+
+		int timestamp=-1;
+		if (cursor != null) {
+			if (cursor.moveToFirst()) {
+				timestamp = cursor.getInt(1);
+			}
+			cursor.close();
+		}
+		return timestamp;
+	}
+
+
+
+	/**
 	 * Creates a new empty playlist
 	 *
 	 * @param context the context to use
@@ -653,6 +692,11 @@ public class MediaLibrary  {
 		 * Various flags of this entry, see SONG_FLAG...
 		 */
 		String FLAGS = "_flags";
+		/**
+		 * Contains the last known timestamp of the song.
+		 * This is important for audiobooks/podcasts
+		 */
+		String TIMESTAMP_LAST_PLAY = "timestamp_last_play";
 	}
 
 	// Columns of Album entries
@@ -681,6 +725,10 @@ public class MediaLibrary  {
 		 * The mtime of this item
 		 */
 		String MTIME = "mtime";
+		/**
+		 * The id of the last played song from this album
+		 */
+		String LAST_TRACK_PLAYED = "last_track_played";
 	}
 
 	// Columns of Contributors entries

--- a/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaLibrary.java
+++ b/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaLibrary.java
@@ -395,7 +395,7 @@ public class MediaLibrary  {
 	}
 
 	/**
-	 * Updates the timestamp of a played song
+	 * Get the timestamp of a played song
 	 *
 	 * @param context the context to use
 	 * @param id the song id to update
@@ -419,7 +419,42 @@ public class MediaLibrary  {
 		return timestamp;
 	}
 
+	/**
+	 * Updates the timestamp of a played song
+	 *
+	 * @param context the context to use
+	 * @param songId the song id
+	 * @param albumId the album id to update
+	 */
+	public static void updateAlbumLastSong(Context context, long songId, long albumId) {
+		String selection = MediaLibrary.AlbumColumns._ID+"="+albumId;
+		getBackend(context).execSQL("UPDATE "+MediaLibrary.TABLE_ALBUMS+" SET "+AlbumColumns.LAST_TRACK_PLAYED+"="+songId+" WHERE "+selection);
+	}
 
+	/**
+	 * Get the last played song of an album
+	 *
+	 * @param context the context to use
+	 * @param id the song id to update
+	 * @return the songid
+	 */
+	public static long getAlbumLastSong(Context context, long id) {
+
+		String[] projection = {AlbumColumns._ID, AlbumColumns.LAST_TRACK_PLAYED};
+		String selection = AlbumColumns._ID + " = ?";
+		String[] selectionArgs = { String.valueOf(id) };
+
+		Cursor cursor = MediaLibrary.queryLibrary(context, MediaLibrary.TABLE_ALBUMS, projection, selection, selectionArgs, null);
+
+		long timestamp=-1;
+		if (cursor != null) {
+			if (cursor.moveToFirst()) {
+				timestamp = cursor.getLong(1);
+			}
+			cursor.close();
+		}
+		return timestamp;
+	}
 
 	/**
 	 * Creates a new empty playlist

--- a/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaLibrary.java
+++ b/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaLibrary.java
@@ -457,6 +457,41 @@ public class MediaLibrary  {
 	}
 
 	/**
+	 * Sets the state if the album should use the last played timestamp on playstart
+	 *
+	 * @param context the context to use
+	 * @param albumId the album id to update
+	 * @param startAtTimestamp the album id to update
+	 */
+	public static void updateAlbumUseSongTimestamp(Context context, long albumId, boolean startAtTimestamp) {
+		int state = 0;
+		if(startAtTimestamp){
+			state = 1;
+		}
+
+		String selection = MediaLibrary.AlbumColumns._ID+"="+albumId;
+		getBackend(context).execSQL("UPDATE "+MediaLibrary.TABLE_ALBUMS+" SET "+AlbumColumns.START_AT_TRACKTIMESTAMP+"="+state+" WHERE "+selection);
+	}
+
+	public static int getAlbumUseSongTimestamp(Context context, long id) {
+
+		String[] projection = {AlbumColumns._ID, AlbumColumns.START_AT_TRACKTIMESTAMP};
+		String selection = AlbumColumns._ID + " = ?";
+		String[] selectionArgs = { String.valueOf(id) };
+
+		Cursor cursor = MediaLibrary.queryLibrary(context, MediaLibrary.TABLE_ALBUMS, projection, selection, selectionArgs, null);
+
+		int state=-1;
+		if (cursor != null) {
+			if (cursor.moveToFirst()) {
+				state = cursor.getInt(1);
+			}
+			cursor.close();
+		}
+		return state;
+	}
+
+	/**
 	 * Creates a new empty playlist
 	 *
 	 * @param context the context to use
@@ -764,6 +799,10 @@ public class MediaLibrary  {
 		 * The id of the last played song from this album
 		 */
 		String LAST_TRACK_PLAYED = "last_track_played";
+		/**
+		 * The id of the last played song from this album
+		 */
+		String START_AT_TRACKTIMESTAMP = "start_at_tracktimestamp";
 	}
 
 	// Columns of Contributors entries

--- a/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaLibraryBackend.java
+++ b/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaLibraryBackend.java
@@ -35,7 +35,7 @@ public class MediaLibraryBackend extends SQLiteOpenHelper {
 	/**
 	 * The database version we are using
 	 */
-	private static final int DATABASE_VERSION = 20190225;
+	private static final int DATABASE_VERSION = 20190228;
 	/**
 	 * on-disk file to store the database
 	 */

--- a/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaLibraryBackend.java
+++ b/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaLibraryBackend.java
@@ -35,7 +35,7 @@ public class MediaLibraryBackend extends SQLiteOpenHelper {
 	/**
 	 * The database version we are using
 	 */
-	private static final int DATABASE_VERSION = 20190210;
+	private static final int DATABASE_VERSION = 20190225;
 	/**
 	 * on-disk file to store the database
 	 */

--- a/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaMigrations.java
+++ b/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaMigrations.java
@@ -49,4 +49,19 @@ public class MediaMigrations {
 		cursor.close();
 	}
 
+	/**
+	 * Migrate to 20190228
+	 * Add fields for track-timestamp and albumposition
+	 *
+	 * @param dbh the database to work on
+	 **/
+	static void migrate_to_20190228(SQLiteDatabase dbh) {
+		Log.v("VanillaMusic", "migrate_to_20190228");
+		dbh.execSQL("ALTER TABLE "+MediaLibrary.TABLE_ALBUMS+" ADD COLUMN "+MediaLibrary.AlbumColumns.LAST_TRACK_PLAYED+" INTEGER;");
+		dbh.execSQL("ALTER TABLE "+MediaLibrary.TABLE_ALBUMS+" ADD COLUMN "+MediaLibrary.AlbumColumns.START_AT_TRACKTIMESTAMP+" INTEGER DEFAULT -1;");
+		dbh.execSQL("ALTER TABLE "+MediaLibrary.TABLE_SONGS+" ADD COLUMN "+MediaLibrary.SongColumns.TIMESTAMP_LAST_PLAY+" INTEGER;");
+
+
+	}
+
 }

--- a/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaSchema.java
+++ b/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaSchema.java
@@ -50,7 +50,7 @@ public class MediaSchema {
 	  + MediaLibrary.AlbumColumns.PRIMARY_ALBUM_YEAR	  +" INTEGER, "
 	  + MediaLibrary.AlbumColumns.PRIMARY_ARTIST_ID 	  +" INTEGER NOT NULL DEFAULT 0, "
 	  + MediaLibrary.AlbumColumns.LAST_TRACK_PLAYED 	  +" INTEGER, "
-	  + MediaLibrary.AlbumColumns.START_AT_TRACKTIMESTAMP +" INTEGER, "
+	  + MediaLibrary.AlbumColumns.START_AT_TRACKTIMESTAMP +" INTEGER DEFAULT -1, "
 	  + MediaLibrary.AlbumColumns.MTIME             	  +" TIMESTAMP DEFAULT CURRENT_TIMESTAMP "
 	  + ");";
 

--- a/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaSchema.java
+++ b/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaSchema.java
@@ -24,19 +24,20 @@ public class MediaSchema {
 	 * SQL Schema of `songs' table
 	 */
 	private static final String DATABASE_CREATE_SONGS = "CREATE TABLE "+ MediaLibrary.TABLE_SONGS + " ("
-	  + MediaLibrary.SongColumns._ID          +" INTEGER PRIMARY KEY, "
-	  + MediaLibrary.SongColumns.TITLE        +" TEXT NOT NULL, "
-	  + MediaLibrary.SongColumns.TITLE_SORT   +" VARCHAR(64) NOT NULL, "
-	  + MediaLibrary.SongColumns.SONG_NUMBER  +" INTEGER, "
-	  + MediaLibrary.SongColumns.DISC_NUMBER  +" INTEGER, "
-	  + MediaLibrary.SongColumns.YEAR         +" INTEGER, "
-	  + MediaLibrary.SongColumns.ALBUM_ID     +" INTEGER NOT NULL, "
-	  + MediaLibrary.SongColumns.PLAYCOUNT    +" INTEGER NOT NULL DEFAULT 0, "
-	  + MediaLibrary.SongColumns.SKIPCOUNT    +" INTEGER NOT NULL DEFAULT 0, "
-	  + MediaLibrary.SongColumns.MTIME        +" TIMESTAMP DEFAULT (strftime('%s', CURRENT_TIMESTAMP)), "
-	  + MediaLibrary.SongColumns.DURATION     +" INTEGER NOT NULL, "
-	  + MediaLibrary.SongColumns.PATH         +" VARCHAR(4096) NOT NULL, "
-	  + MediaLibrary.SongColumns.FLAGS        +" INTEGER NOT NULL DEFAULT 0 "
+	  + MediaLibrary.SongColumns._ID                +" INTEGER PRIMARY KEY, "
+	  + MediaLibrary.SongColumns.TITLE              +" TEXT NOT NULL, "
+	  + MediaLibrary.SongColumns.TITLE_SORT         +" VARCHAR(64) NOT NULL, "
+	  + MediaLibrary.SongColumns.SONG_NUMBER        +" INTEGER, "
+	  + MediaLibrary.SongColumns.DISC_NUMBER        +" INTEGER, "
+	  + MediaLibrary.SongColumns.YEAR               +" INTEGER, "
+	  + MediaLibrary.SongColumns.ALBUM_ID           +" INTEGER NOT NULL, "
+	  + MediaLibrary.SongColumns.PLAYCOUNT          +" INTEGER NOT NULL DEFAULT 0, "
+	  + MediaLibrary.SongColumns.SKIPCOUNT          +" INTEGER NOT NULL DEFAULT 0, "
+	  + MediaLibrary.SongColumns.MTIME              +" TIMESTAMP DEFAULT (strftime('%s', CURRENT_TIMESTAMP)), "
+	  + MediaLibrary.SongColumns.DURATION           +" INTEGER NOT NULL, "
+	  + MediaLibrary.SongColumns.TIMESTAMP_LAST_PLAY+" INTEGER, "
+	  + MediaLibrary.SongColumns.PATH               +" VARCHAR(4096) NOT NULL, "
+	  + MediaLibrary.SongColumns.FLAGS              +" INTEGER NOT NULL DEFAULT 0 "
 	  + ");";
 
 	/**
@@ -48,6 +49,7 @@ public class MediaSchema {
 	  + MediaLibrary.AlbumColumns.ALBUM_SORT        +" VARCHAR(64) NOT NULL, "
 	  + MediaLibrary.AlbumColumns.PRIMARY_ALBUM_YEAR+" INTEGER, "
 	  + MediaLibrary.AlbumColumns.PRIMARY_ARTIST_ID +" INTEGER NOT NULL DEFAULT 0, "
+	  + MediaLibrary.AlbumColumns.LAST_TRACK_PLAYED +" INTEGER, "
 	  + MediaLibrary.AlbumColumns.MTIME             +" TIMESTAMP DEFAULT CURRENT_TIMESTAMP "
 	  + ");";
 

--- a/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaSchema.java
+++ b/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaSchema.java
@@ -367,6 +367,10 @@ public class MediaSchema {
 		if (oldVersion < 20190210) {
 			dbh.execSQL(VIEW_CREATE_PLAYLISTS);
 		}
+
+		if(oldVersion < 20190228){
+			MediaMigrations.migrate_to_20190228(dbh);
+		}
 	}
 
 }

--- a/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaSchema.java
+++ b/app/src/main/java/ch/blinkenlights/android/medialibrary/MediaSchema.java
@@ -44,13 +44,14 @@ public class MediaSchema {
 	 * SQL Schema of `albums' table
 	 */
 	private static final String DATABASE_CREATE_ALBUMS = "CREATE TABLE "+ MediaLibrary.TABLE_ALBUMS + " ("
-	  + MediaLibrary.AlbumColumns._ID               +" INTEGER PRIMARY KEY, "
-	  + MediaLibrary.AlbumColumns.ALBUM             +" TEXT NOT NULL, "
-	  + MediaLibrary.AlbumColumns.ALBUM_SORT        +" VARCHAR(64) NOT NULL, "
-	  + MediaLibrary.AlbumColumns.PRIMARY_ALBUM_YEAR+" INTEGER, "
-	  + MediaLibrary.AlbumColumns.PRIMARY_ARTIST_ID +" INTEGER NOT NULL DEFAULT 0, "
-	  + MediaLibrary.AlbumColumns.LAST_TRACK_PLAYED +" INTEGER, "
-	  + MediaLibrary.AlbumColumns.MTIME             +" TIMESTAMP DEFAULT CURRENT_TIMESTAMP "
+	  + MediaLibrary.AlbumColumns._ID               	  +" INTEGER PRIMARY KEY, "
+	  + MediaLibrary.AlbumColumns.ALBUM             	  +" TEXT NOT NULL, "
+	  + MediaLibrary.AlbumColumns.ALBUM_SORT        	  +" VARCHAR(64) NOT NULL, "
+	  + MediaLibrary.AlbumColumns.PRIMARY_ALBUM_YEAR	  +" INTEGER, "
+	  + MediaLibrary.AlbumColumns.PRIMARY_ARTIST_ID 	  +" INTEGER NOT NULL DEFAULT 0, "
+	  + MediaLibrary.AlbumColumns.LAST_TRACK_PLAYED 	  +" INTEGER, "
+	  + MediaLibrary.AlbumColumns.START_AT_TRACKTIMESTAMP +" INTEGER, "
+	  + MediaLibrary.AlbumColumns.MTIME             	  +" TIMESTAMP DEFAULT CURRENT_TIMESTAMP "
 	  + ");";
 
 	/**

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
@@ -632,6 +632,8 @@ public class LibraryActivity
 	private static final int CTX_MENU_ADD_TO_HOMESCREEN = 13;
 	private static final int CTX_MENU_ADD_TO_PLAYLIST = 14;
 	private static final int CTX_MENU_PLAY_ALL_START_WITH_LAST_PLAYED = 15;
+	private static final int CTX_MENU_STORE_TIMESTAMP_FOR_ALBUM = 16;
+	private static final int CTX_MENU_DONT_STORE_TIMESTAMP_FOR_ALBUM = 17;
 
 	/**
 	 * Creates a context menu for an adapter row.
@@ -697,6 +699,15 @@ public class LibraryActivity
 
 			fm.addSpacer(90);
 			fm.add(CTX_MENU_DELETE, 90, R.drawable.menu_delete, R.string.delete).setIntent(rowData);
+
+			int timestampstate = MediaLibrary.getAlbumUseSongTimestamp(this, rowData.getLongExtra("id", LibraryAdapter.INVALID_ID));
+			if(type == MediaUtils.TYPE_ALBUM){
+				if (timestampstate == 0) {
+					fm.add(CTX_MENU_STORE_TIMESTAMP_FOR_ALBUM, 90, R.drawable.menu_delete, R.string.storeAlbumTimestamp).setIntent(rowData);
+				}else if (timestampstate == 1){
+					fm.add(CTX_MENU_DONT_STORE_TIMESTAMP_FOR_ALBUM, 90, R.drawable.menu_delete, R.string.dontStoreAlbumTimestamp).setIntent(rowData);
+				}
+			}
 		}
 		fm.show(view, x, y);
 		return true;
@@ -737,7 +748,26 @@ public class LibraryActivity
 			break;
 		case CTX_MENU_PLAY_ALL_START_WITH_LAST_PLAYED:
 			pickSongs(intent, ACTION_ENQUEUE_ALL);
-			Log.e("testlastsong", MediaLibrary.getAlbumLastSong(this, String.valueOf(intent.getLongExtra("id", LibraryAdapter.INVALID_ID))));
+			//Log.e("testlastsong", MediaLibrary.getAlbumLastSong(this, String.valueOf(intent.getLongExtra("id", LibraryAdapter.INVALID_ID))));
+			break;
+		case CTX_MENU_STORE_TIMESTAMP_FOR_ALBUM:
+			//pickSongs(intent, ACTION_ENQUEUE_ALL);
+			long albumid1=intent.getLongExtra("id", LibraryAdapter.INVALID_ID);
+			Log.e("store", "store");
+			Log.e("store", ""+albumid1);
+			Log.e("store", ""+MediaLibrary.getAlbumUseSongTimestamp(this, albumid1));
+			MediaLibrary.updateAlbumUseSongTimestamp(this, albumid1,true);
+			Log.e("store", ""+MediaLibrary.getAlbumUseSongTimestamp(this, albumid1));
+			break;
+		case CTX_MENU_DONT_STORE_TIMESTAMP_FOR_ALBUM:
+			//pickSongs(intent, ACTION_ENQUEUE_ALL);
+			long albumid=intent.getLongExtra("id", LibraryAdapter.INVALID_ID);
+			Log.e("store", "dontstore");
+			Log.e("store", ""+albumid);
+			Log.e("store", ""+MediaLibrary.getAlbumUseSongTimestamp(this, albumid));
+			MediaLibrary.updateAlbumUseSongTimestamp(this, albumid,false);
+			Log.e("store", ""+MediaLibrary.getAlbumUseSongTimestamp(this, albumid));
+
 			break;
 		case CTX_MENU_ENQUEUE_ALL:
 			pickSongs(intent, ACTION_ENQUEUE_ALL);

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
@@ -760,23 +760,10 @@ public class LibraryActivity
 			//Log.e("testlastsong", MediaLibrary.getAlbumLastSong(this, String.valueOf(intent.getLongExtra("id", LibraryAdapter.INVALID_ID))));
 			break;
 		case CTX_MENU_STORE_TIMESTAMP_FOR_ALBUM:
-			//pickSongs(intent, ACTION_ENQUEUE_ALL);
-			long albumid1=intent.getLongExtra("id", LibraryAdapter.INVALID_ID);
-			Log.e("store", "store");
-			Log.e("store", ""+albumid1);
-			Log.e("store", ""+MediaLibrary.getAlbumUseSongTimestamp(this, albumid1));
-			MediaLibrary.updateAlbumUseSongTimestamp(this, albumid1,true);
-			Log.e("store", ""+MediaLibrary.getAlbumUseSongTimestamp(this, albumid1));
+			MediaLibrary.updateAlbumUseSongTimestamp(this, intent.getLongExtra("id", LibraryAdapter.INVALID_ID),true);
 			break;
 		case CTX_MENU_DONT_STORE_TIMESTAMP_FOR_ALBUM:
-			//pickSongs(intent, ACTION_ENQUEUE_ALL);
-			long albumid=intent.getLongExtra("id", LibraryAdapter.INVALID_ID);
-			Log.e("store", "dontstore");
-			Log.e("store", ""+albumid);
-			Log.e("store", ""+MediaLibrary.getAlbumUseSongTimestamp(this, albumid));
-			MediaLibrary.updateAlbumUseSongTimestamp(this, albumid,false);
-			Log.e("store", ""+MediaLibrary.getAlbumUseSongTimestamp(this, albumid));
-
+			MediaLibrary.updateAlbumUseSongTimestamp(this, intent.getLongExtra("id", LibraryAdapter.INVALID_ID),false);
 			break;
 		case CTX_MENU_ENQUEUE_ALL:
 			pickSongs(intent, ACTION_ENQUEUE_ALL);

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
@@ -687,16 +687,16 @@ public class LibraryActivity
 			if(type == MediaUtils.TYPE_ALBUM){
 				fm.addSpacer(10);
 				if (timestampstate == 0) {
-					fm.add(CTX_MENU_STORE_TIMESTAMP_FOR_ALBUM, 11, R.drawable.ic_add_black_24dp, R.string.storeAlbumTimestamp).setIntent(rowData);
+					fm.add(CTX_MENU_STORE_TIMESTAMP_FOR_ALBUM, 11, R.drawable.ic_add_black_24dp, R.string.store_album_timestamp).setIntent(rowData);
 				}else if (timestampstate == 1){
-					fm.add(CTX_MENU_DONT_STORE_TIMESTAMP_FOR_ALBUM, 11, R.drawable.ic_clear_black_24dp, R.string.dontStoreAlbumTimestamp).setIntent(rowData);
+					fm.add(CTX_MENU_DONT_STORE_TIMESTAMP_FOR_ALBUM, 11, R.drawable.ic_clear_black_24dp, R.string.dont_store_album_timestamp).setIntent(rowData);
 				}else{
 
 					SharedPreferences settings = SharedPrefHelper.getSettings(this);
 					if(!settings.getBoolean(PrefKeys.JUMP_TO_LAST_POSITION_OF_TRACK_STATE, PrefDefaults.JUMP_TO_LAST_POSITION_OF_TRACK_STATE)){
-						fm.add(CTX_MENU_STORE_TIMESTAMP_FOR_ALBUM, 11, R.drawable.ic_add_black_24dp, R.string.storeAlbumTimestamp).setIntent(rowData);
+						fm.add(CTX_MENU_STORE_TIMESTAMP_FOR_ALBUM, 11, R.drawable.ic_add_black_24dp, R.string.store_album_timestamp).setIntent(rowData);
 					}else {
-						fm.add(CTX_MENU_DONT_STORE_TIMESTAMP_FOR_ALBUM, 11, R.drawable.ic_clear_black_24dp, R.string.dontStoreAlbumTimestamp).setIntent(rowData);
+						fm.add(CTX_MENU_DONT_STORE_TIMESTAMP_FOR_ALBUM, 11, R.drawable.ic_clear_black_24dp, R.string.dont_store_album_timestamp).setIntent(rowData);
 					}
 				}
 			}

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
@@ -41,6 +41,7 @@ import android.os.Handler;
 import android.os.Message;
 import android.support.iosched.tabs.VanillaTabLayout;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -630,6 +631,7 @@ public class LibraryActivity
 	private static final int CTX_MENU_SHOW_DETAILS = 12;
 	private static final int CTX_MENU_ADD_TO_HOMESCREEN = 13;
 	private static final int CTX_MENU_ADD_TO_PLAYLIST = 14;
+	private static final int CTX_MENU_PLAY_ALL_START_WITH_LAST_PLAYED = 15;
 
 	/**
 	 * Creates a context menu for an adapter row.
@@ -664,8 +666,14 @@ public class LibraryActivity
 			if (type <= MediaUtils.TYPE_SONG || type == MediaUtils.TYPE_FILE)
 				fm.add(CTX_MENU_PLAY_ALL, 1, R.drawable.menu_play_all, R.string.play_all).setIntent(rowData);
 
+
+			if(type == MediaUtils.TYPE_ALBUM){
+				fm.add(CTX_MENU_PLAY_ALL_START_WITH_LAST_PLAYED, 1, R.drawable.menu_play_all, R.string.play_all_start_with_last_played).setIntent(rowData);
+			}
+
 			fm.add(CTX_MENU_ENQUEUE_AS_NEXT, 1, R.drawable.menu_enqueue_as_next, R.string.enqueue_as_next).setIntent(rowData);
 			fm.add(CTX_MENU_ENQUEUE, 1, R.drawable.menu_enqueue, R.string.enqueue).setIntent(rowData);
+
 
 			if (type == MediaUtils.TYPE_PLAYLIST) {
 				fm.add(CTX_MENU_RENAME_PLAYLIST, 0, R.drawable.menu_edit, R.string.rename).setIntent(rowData);
@@ -686,6 +694,7 @@ public class LibraryActivity
 					}
 				}
 			}
+
 			fm.addSpacer(90);
 			fm.add(CTX_MENU_DELETE, 90, R.drawable.menu_delete, R.string.delete).setIntent(rowData);
 		}
@@ -725,6 +734,10 @@ public class LibraryActivity
 			break;
 		case CTX_MENU_PLAY_ALL:
 			pickSongs(intent, ACTION_PLAY_ALL);
+			break;
+		case CTX_MENU_PLAY_ALL_START_WITH_LAST_PLAYED:
+			pickSongs(intent, ACTION_ENQUEUE_ALL);
+			Log.e("testlastsong", MediaLibrary.getAlbumLastSong(this, String.valueOf(intent.getLongExtra("id", LibraryAdapter.INVALID_ID))));
 			break;
 		case CTX_MENU_ENQUEUE_ALL:
 			pickSongs(intent, ACTION_ENQUEUE_ALL);

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
@@ -683,6 +683,24 @@ public class LibraryActivity
 				fm.add(CTX_MENU_EXPAND, 2, R.drawable.menu_expand, R.string.expand).setIntent(rowData);
 			}
 
+			int timestampstate = MediaLibrary.getAlbumUseSongTimestamp(this, rowData.getLongExtra("id", LibraryAdapter.INVALID_ID));
+			if(type == MediaUtils.TYPE_ALBUM){
+				fm.addSpacer(10);
+				if (timestampstate == 0) {
+					fm.add(CTX_MENU_STORE_TIMESTAMP_FOR_ALBUM, 11, R.drawable.ic_add_black_24dp, R.string.storeAlbumTimestamp).setIntent(rowData);
+				}else if (timestampstate == 1){
+					fm.add(CTX_MENU_DONT_STORE_TIMESTAMP_FOR_ALBUM, 11, R.drawable.ic_clear_black_24dp, R.string.dontStoreAlbumTimestamp).setIntent(rowData);
+				}else{
+
+					SharedPreferences settings = SharedPrefHelper.getSettings(this);
+					if(!settings.getBoolean(PrefKeys.JUMP_TO_LAST_POSITION_OF_TRACK_STATE, PrefDefaults.JUMP_TO_LAST_POSITION_OF_TRACK_STATE)){
+						fm.add(CTX_MENU_STORE_TIMESTAMP_FOR_ALBUM, 11, R.drawable.ic_add_black_24dp, R.string.storeAlbumTimestamp).setIntent(rowData);
+					}else {
+						fm.add(CTX_MENU_DONT_STORE_TIMESTAMP_FOR_ALBUM, 11, R.drawable.ic_clear_black_24dp, R.string.dontStoreAlbumTimestamp).setIntent(rowData);
+					}
+				}
+			}
+
 			if (type == MediaUtils.TYPE_SONG || type == MediaUtils.TYPE_ALBUM) {
 				fm.addSpacer(30);
 				fm.add(CTX_MENU_MORE_FROM_ARTIST, 30, R.drawable.menu_artist, R.string.more_from_artist).setIntent(rowData);
@@ -699,15 +717,6 @@ public class LibraryActivity
 
 			fm.addSpacer(90);
 			fm.add(CTX_MENU_DELETE, 90, R.drawable.menu_delete, R.string.delete).setIntent(rowData);
-
-			int timestampstate = MediaLibrary.getAlbumUseSongTimestamp(this, rowData.getLongExtra("id", LibraryAdapter.INVALID_ID));
-			if(type == MediaUtils.TYPE_ALBUM){
-				if (timestampstate == 0) {
-					fm.add(CTX_MENU_STORE_TIMESTAMP_FOR_ALBUM, 90, R.drawable.menu_delete, R.string.storeAlbumTimestamp).setIntent(rowData);
-				}else if (timestampstate == 1){
-					fm.add(CTX_MENU_DONT_STORE_TIMESTAMP_FOR_ALBUM, 90, R.drawable.menu_delete, R.string.dontStoreAlbumTimestamp).setIntent(rowData);
-				}
-			}
 		}
 		fm.show(view, x, y);
 		return true;

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
@@ -493,6 +493,25 @@ public class LibraryActivity
 		if (action == ACTION_LAST_USED)
 			action = mLastAction;
 
+
+		int type = rowData.getIntExtra(LibraryAdapter.DATA_TYPE, MediaUtils.TYPE_INVALID);
+		int timestampAlbumState = MediaLibrary.getAlbumUseSongTimestamp(this, rowData.getLongExtra("id", LibraryAdapter.INVALID_ID));
+
+		boolean state = false;
+		if(timestampAlbumState == 1){
+			state = true;
+		}
+
+		SharedPreferences settings = SharedPrefHelper.getSettings(this);
+		if(settings.getBoolean(PrefKeys.JUMP_TO_LAST_POSITION_OF_TRACK_STATE, PrefDefaults.JUMP_TO_LAST_POSITION_OF_TRACK_STATE) && timestampAlbumState == -1){
+			state = true;
+		}
+
+		if (type == MediaUtils.TYPE_ALBUM && state){
+			pickSongs(rowData, ACTION_CONTINUE);
+			return;
+		}
+
 		boolean tryExpand = action == ACTION_EXPAND || action == ACTION_EXPAND_OR_PLAY_ALL;
 		if (tryExpand && rowData.getBooleanExtra(LibraryAdapter.DATA_EXPANDABLE, false)) {
 			onItemExpanded(rowData);

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
@@ -405,12 +405,8 @@ public class LibraryActivity
 			}
 		}
 
-		if (action == ACTION_CONTINUE) {
-			effectiveAction = ACTION_PLAY;
-		}
-
 		boolean all = false;
-		if (action == ACTION_PLAY_ALL || action == ACTION_ENQUEUE_ALL || action == ACTION_CONTINUE) {
+		if (action == ACTION_PLAY_ALL || action == ACTION_ENQUEUE_ALL) {
 			boolean notPlayAllAdapter =
 				(id == LibraryAdapter.HEADER_ID)
 				|| !(type <= MediaUtils.TYPE_SONG || type == MediaUtils.TYPE_FILE);
@@ -418,11 +414,13 @@ public class LibraryActivity
 				effectiveAction = ACTION_ENQUEUE;
 			} else if (effectiveAction == ACTION_PLAY_ALL && notPlayAllAdapter) {
 				effectiveAction = ACTION_PLAY;
-			} else if (action == ACTION_CONTINUE && notPlayAllAdapter) {
-				effectiveAction = ACTION_PLAY;
 			} else {
 				all = true;
 			}
+		}
+
+		if (action == ACTION_CONTINUE) {
+			effectiveAction = ACTION_PLAY;
 		}
 
 		if (id == LibraryAdapter.HEADER_ID)

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -1402,7 +1402,6 @@ public final class PlaybackService extends Service
 		try {
 			mMediaPlayerInitialized = false;
 			mMediaPlayer.reset();
-			mPlaybackTimestampHandler.start(mMediaPlayer);
 			mPlaybackTimestampHandler.setSong(song);
 
 			if(mPreparedMediaPlayer.isPlaying()) {
@@ -1476,8 +1475,9 @@ public final class PlaybackService extends Service
 		int time = mPlaybackTimestampHandler.getInitialTimestamp();
 
 		if(time > 0 && jump){
-			seekToPosition(time*1000);
+			seekToPosition(time);
 		}
+		mPlaybackTimestampHandler.start(mMediaPlayer);
 		updateNotification();
 
 	}

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -1489,7 +1489,9 @@ public final class PlaybackService extends Service
 		// Count this song as played
 		mHandler.sendMessageDelayed(mHandler.obtainMessage(MSG_UPDATE_PLAYCOUNTS, 1, 0, mCurrentSong), 800);
 
+
 		mPlaybackTimestampHandler.stopUpdates();
+		mPlaybackTimestampHandler.updateToZero();
 
 		if (finishAction(mState) == SongTimeline.FINISH_REPEAT_CURRENT) {
 			setCurrentSong(0);

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -1246,6 +1246,9 @@ public final class PlaybackService extends Service
 	 */
 	public int play()
 	{
+
+		//restart Playbackhandler if it stopped
+		mPlaybackTimestampHandler.start(mMediaPlayer);
 		synchronized (mStateLock) {
 			if ((mState & FLAG_EMPTY_QUEUE) != 0) {
 				setFinishAction(SongTimeline.FINISH_RANDOM);

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -524,7 +524,10 @@ public final class PlaybackService extends Service
 		initWidgets();
 
 		updateState(state);
-		setCurrentSong(0);
+		Song s = setCurrentSong(0);
+		if(s!=null){
+			prepareTimeForPlayback(s);
+		}
 
 		sInstance = this;
 		synchronized (sWait) {
@@ -549,7 +552,9 @@ public final class PlaybackService extends Service
 			if (earlyNotification) {
 				Song song = mCurrentSong != null ? mCurrentSong : new Song(-1);
 				startForeground(NOTIFICATION_ID, createNotification(song, mState, VISIBILITY_WHEN_PLAYING));
-				processSong(song);
+				if(song!=null){
+					prepareTimeForPlayback(song);
+				}
 			}
 
 
@@ -1460,6 +1465,13 @@ public final class PlaybackService extends Service
 
 		}
 
+		prepareTimeForPlayback(song);
+		mPlaybackTimestampHandler.start(mMediaPlayer);
+		updateNotification();
+
+	}
+
+	private void prepareTimeForPlayback(Song song){
 
 		int state = MediaLibrary.getAlbumUseSongTimestamp(this, song.albumId);
 		boolean jump=false;
@@ -1476,8 +1488,11 @@ public final class PlaybackService extends Service
 			jump=true;
 		}
 
-		int time = mPlaybackTimestampHandler.getInitialTimestamp();
+		int time = mPlaybackTimestampHandler.getInitialTimestamp() ;
 
+		if(time == -1){
+			jump=false;
+		}
 		if(time > 0 && jump){
 			seekToPosition(time);
 		}

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -1246,7 +1246,6 @@ public final class PlaybackService extends Service
 	 */
 	public int play()
 	{
-
 		//restart Playbackhandler if it stopped
 		mPlaybackTimestampHandler.start(mMediaPlayer);
 		synchronized (mStateLock) {
@@ -1462,8 +1461,6 @@ public final class PlaybackService extends Service
 		int state = MediaLibrary.getAlbumUseSongTimestamp(this, song.albumId);
 		boolean jump=false;
 
-
-
 		SharedPreferences settings = SharedPrefHelper.getSettings(this);
 		boolean settingForJump = settings.getBoolean(PrefKeys.JUMP_TO_LAST_POSITION_OF_TRACK_STATE, PrefDefaults.JUMP_TO_LAST_POSITION_OF_TRACK_STATE);
 
@@ -1477,8 +1474,9 @@ public final class PlaybackService extends Service
 		}
 
 		int time = mPlaybackTimestampHandler.getInitialTimestamp();
+
 		if(time > 0 && jump){
-			seekToPosition(time);
+			seekToPosition(time*1000);
 		}
 		updateNotification();
 

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -549,7 +549,11 @@ public final class PlaybackService extends Service
 			if (earlyNotification) {
 				Song song = mCurrentSong != null ? mCurrentSong : new Song(-1);
 				startForeground(NOTIFICATION_ID, createNotification(song, mState, VISIBILITY_WHEN_PLAYING));
+				processSong(song);
 			}
+
+
+
 
 			if (ACTION_TOGGLE_PLAYBACK.equals(action)) {
 				playPause();

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -25,6 +25,7 @@ package ch.blinkenlights.android.vanilla;
 
 import ch.blinkenlights.android.medialibrary.MediaLibrary;
 import ch.blinkenlights.android.medialibrary.LibraryObserver;
+import ch.blinkenlights.android.medialibrary.MediaLibraryBackend;
 import ch.blinkenlights.android.vanilla.playback.PlaybackTimestampHandler;
 
 import android.app.Notification;
@@ -1454,8 +1455,26 @@ public final class PlaybackService extends Service
 
 		}
 
+
+		int state = MediaLibrary.getAlbumUseSongTimestamp(this, song.albumId);
+		boolean jump=false;
+
+
+
+		SharedPreferences settings = SharedPrefHelper.getSettings(this);
+		boolean settingForJump = settings.getBoolean(PrefKeys.JUMP_TO_LAST_POSITION_OF_TRACK_STATE, PrefDefaults.JUMP_TO_LAST_POSITION_OF_TRACK_STATE);
+
+		if(state==-1){
+			if(settingForJump){
+				jump = true;
+			}
+		}
+		if(state==1){
+			jump=true;
+		}
+
 		int time = mPlaybackTimestampHandler.getInitialTimestamp();
-		if(time > 0){
+		if(time > 0 && jump){
 			seekToPosition(time);
 		}
 		updateNotification();

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PrefDefaults.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PrefDefaults.java
@@ -80,4 +80,5 @@ public class PrefDefaults {
 	public static final String  PLAYLIST_SYNC_FOLDER = "/sdcard/Playlists";
 	public static final boolean PLAYLIST_EXPORT_RELATIVE_PATHS = false;
 	public static final boolean JUMP_TO_ENQUEUED_ON_PLAY = true;
+	public static final boolean JUMP_TO_LAST_POSITION_OF_TRACK_STATE = false;
 }

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PrefKeys.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PrefKeys.java
@@ -81,4 +81,5 @@ public class PrefKeys {
 	public static final String PLAYLIST_SYNC_FOLDER = "playlist_sync_folder";
 	public static final String PLAYLIST_EXPORT_RELATIVE_PATHS = "playlist_export_relative_paths";
 	public static final String JUMP_TO_ENQUEUED_ON_PLAY = "jump_to_enqueued_on_play";
+	public static final String JUMP_TO_LAST_POSITION_OF_TRACK_STATE = "jump_to_last_position_of_track_state";
 }

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
@@ -28,14 +28,16 @@ import ch.blinkenlights.android.vanilla.VanillaMediaPlayer;
 
 public class PlaybackTimestampHandler {
 
-	final Handler mHandler = new Handler();
-
-	private MediaLibraryBackend mlb;
+	private final Handler mHandler = new Handler();
 	private Context c;
 
 	private boolean alreadyUpdating=false;
 	private Song mSong;
 	private int mTimestamp;
+
+
+
+	private static final int mDelayUpdate = 2000;
 
 	private static String TAG = "PlaybackUpdateHandler";
 
@@ -50,12 +52,6 @@ public class PlaybackTimestampHandler {
 	}
 
 	public void start(VanillaMediaPlayer mediaPlayer) {
-
-		if(!mediaPlayer.isPlaying()){
-			//Log.d(TAG, "Mediaplayer not playing!");
-			//return;
-		}
-
 		if(alreadyUpdating){
 			//Log.d(TAG, "Mediaplayer already updating!");
 			return;
@@ -74,12 +70,13 @@ public class PlaybackTimestampHandler {
 					storeTimestampdataForSong();
 				} finally {
 					//if mediaplayer is not playing, wait longer.
-					int delay=500;
-					if(!vmp.isPlaying()){
-						delay=5000;
-						//Log.d(TAG, "Long Delay: "+delay);
+					if(vmp.isPlaying()){
+						mHandler.postDelayed(this, mDelayUpdate);
+					}else{
+						//Stop Handler if no music is playing.
+						Log.e(TAG, "Mediaplayer not playing, stop updating!");
+						alreadyUpdating=false;
 					}
-					mHandler.postDelayed(this, delay);
 				}
 			}
 		};

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
@@ -96,6 +96,9 @@ public class PlaybackTimestampHandler {
 
 
 	private void storeTimestampdataForSong() {
+		if(mSong == null || mSong.id == 0 || mSong.albumId == 0 || c == null){
+			return;
+		}
 		MediaLibrary.updateSongTimestamp(c, mSong.id, mTimestamp);
 		MediaLibrary.updateAlbumLastSong(c, mSong.id, mSong.albumId);
 	}

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
@@ -100,5 +100,8 @@ public class PlaybackTimestampHandler {
 		MediaLibrary.updateAlbumLastSong(mContext, mSong.id, mSong.albumId);
 	}
 
-
+	public void updateToZero() {
+		MediaLibrary.updateSongTimestamp(mContext, mSong.id, 0);
+		MediaLibrary.updateAlbumLastSong(mContext, mSong.id, mSong.albumId);
+	}
 }

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
@@ -64,7 +64,11 @@ public class PlaybackTimestampHandler {
 				try {
 					//Log.d(TAG, "Timestamp: "+vmp.getCurrentPosition()/1000+" - "+mSong.title+" - "+mSong.id);
 					mTimestamp = vmp.getCurrentPosition();
-					storeTimestampdataForSong();
+
+					//This fixes the timestamp beeing set to 0 if the player has not been initialized
+					if(vmp.isPlaying ()){
+						storeTimestampdataForSong();
+					}
 				} finally {
 					//if mediaplayer is not playing, wait longer.
 					if(vmp.isPlaying()){

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
@@ -101,8 +101,6 @@ public class PlaybackTimestampHandler {
 	private void storeTimestampdataForSong() {
 		MediaLibrary.updateSongTimestamp(c, mSong.id, mTimestamp);
 		MediaLibrary.updateAlbumLastSong(c, mSong.id, mSong.albumId);
-
-
 	}
 
 

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
@@ -62,7 +62,7 @@ public class PlaybackTimestampHandler {
 			@Override
 			public void run() {
 				try {
-					Log.d(TAG, "Timestamp: "+vmp.getCurrentPosition()/1000+" - "+mSong.title+" - "+mSong.id);
+					//Log.d(TAG, "Timestamp: "+vmp.getCurrentPosition()/1000+" - "+mSong.title+" - "+mSong.id);
 					mTimestamp = vmp.getCurrentPosition();
 					storeTimestampdataForSong();
 				} finally {
@@ -71,7 +71,7 @@ public class PlaybackTimestampHandler {
 						mHandler.postDelayed(this, mDelayUpdate);
 					}else{
 						//Stop Handler if no music is playing.
-						Log.e(TAG, "Mediaplayer not playing, stop updating!");
+						//Log.e(TAG, "Mediaplayer not playing, stop updating!");
 						mAlreadyUpdating =false;
 					}
 				}

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2019 Felix Nüsse <felix.nuesse@t-online.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ch.blinkenlights.android.vanilla.playback;
+
+import android.content.Context;
+import android.os.Handler;
+import android.util.Log;
+
+import ch.blinkenlights.android.medialibrary.MediaLibrary;
+import ch.blinkenlights.android.medialibrary.MediaLibraryBackend;
+import ch.blinkenlights.android.vanilla.Song;
+import ch.blinkenlights.android.vanilla.VanillaMediaPlayer;
+
+public class PlaybackTimestampHandler {
+
+	final Handler mHandler = new Handler();
+
+	private MediaLibraryBackend mlb;
+	private Context c;
+
+	private boolean alreadyUpdating=false;
+	private Song mSong;
+	private int mTimestamp;
+
+	private static String TAG = "PlaybackUpdateHandler";
+
+	public PlaybackTimestampHandler(Context c) {
+		this.c = c;
+	}
+
+	public void stopUpdates(){
+		Log.d(TAG, "Called on main thread stopUpdates");
+		mHandler.removeCallbacksAndMessages(null);
+		alreadyUpdating=false;
+	}
+
+	public void start(VanillaMediaPlayer mediaPlayer) {
+
+		if(!mediaPlayer.isPlaying()){
+			//Log.d(TAG, "Mediaplayer not playing!");
+			//return;
+		}
+
+		if(alreadyUpdating){
+			//Log.d(TAG, "Mediaplayer already updating!");
+			return;
+		}
+
+		final VanillaMediaPlayer vmp = mediaPlayer;
+		// Create the Handler object (on the main thread by default)
+
+		// Define the code block to be executed
+		Runnable runnableCode = new Runnable() {
+			@Override
+			public void run() {
+				try {
+					//Log.d(TAG, "Timestamp: "+vmp.getCurrentPosition()+" - "+mSong.title+" - "+mSong.id);
+					mTimestamp = vmp.getCurrentPosition();
+					storeTimestampdataForSong();
+				} finally {
+					//if mediaplayer is not playing, wait longer.
+					int delay=500;
+					if(!vmp.isPlaying()){
+						delay=5000;
+						//Log.d(TAG, "Long Delay: "+delay);
+					}
+					mHandler.postDelayed(this, delay);
+				}
+			}
+		};
+		// Start the initial runnable task by posting through the handler
+		alreadyUpdating=true;
+		mHandler.post(runnableCode);
+		//Log.d(TAG, "Mediaplayer started updating");
+	}
+
+	public void setSong(Song song) {
+		mSong=song;
+	}
+
+	public int getInitialTimestamp() {
+		return MediaLibrary.getSongTimestamp(c, mSong.id);
+	}
+
+
+	private void storeTimestampdataForSong() {
+		MediaLibrary.updateSongTimestamp(c, mSong.id, mTimestamp);
+	}
+
+
+}

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
@@ -22,37 +22,34 @@ import android.os.Handler;
 import android.util.Log;
 
 import ch.blinkenlights.android.medialibrary.MediaLibrary;
-import ch.blinkenlights.android.medialibrary.MediaLibraryBackend;
 import ch.blinkenlights.android.vanilla.Song;
 import ch.blinkenlights.android.vanilla.VanillaMediaPlayer;
 
 public class PlaybackTimestampHandler {
 
-	private final Handler mHandler = new Handler();
-	private Context c;
+	private static final int mDelayUpdate = 2000;
+	private static String TAG = "PlaybackUpdateHandler";
 
-	private boolean alreadyUpdating=false;
+	private final Handler mHandler = new Handler();
+	private Context mContext;
 	private Song mSong;
+
+	private boolean mAlreadyUpdating =false;
 	private int mTimestamp;
 
 
-
-	private static final int mDelayUpdate = 2000;
-
-	private static String TAG = "PlaybackUpdateHandler";
-
 	public PlaybackTimestampHandler(Context c) {
-		this.c = c;
+		this.mContext = c;
 	}
 
 	public void stopUpdates(){
 		Log.d(TAG, "Called on main thread stopUpdates");
 		mHandler.removeCallbacksAndMessages(null);
-		alreadyUpdating=false;
+		mAlreadyUpdating =false;
 	}
 
 	public void start(VanillaMediaPlayer mediaPlayer) {
-		if(alreadyUpdating){
+		if(mAlreadyUpdating){
 			//Log.d(TAG, "Mediaplayer already updating!");
 			return;
 		}
@@ -65,7 +62,7 @@ public class PlaybackTimestampHandler {
 			@Override
 			public void run() {
 				try {
-					//Log.d(TAG, "Timestamp: "+vmp.getCurrentPosition()+" - "+mSong.title+" - "+mSong.id);
+					Log.d(TAG, "Timestamp: "+vmp.getCurrentPosition()/1000+" - "+mSong.title+" - "+mSong.id);
 					mTimestamp = vmp.getCurrentPosition();
 					storeTimestampdataForSong();
 				} finally {
@@ -75,13 +72,13 @@ public class PlaybackTimestampHandler {
 					}else{
 						//Stop Handler if no music is playing.
 						Log.e(TAG, "Mediaplayer not playing, stop updating!");
-						alreadyUpdating=false;
+						mAlreadyUpdating =false;
 					}
 				}
 			}
 		};
 		// Start the initial runnable task by posting through the handler
-		alreadyUpdating=true;
+		mAlreadyUpdating =true;
 		mHandler.post(runnableCode);
 		//Log.d(TAG, "Mediaplayer started updating");
 	}
@@ -91,16 +88,16 @@ public class PlaybackTimestampHandler {
 	}
 
 	public int getInitialTimestamp() {
-		return MediaLibrary.getSongTimestamp(c, mSong.id);
+		return MediaLibrary.getSongTimestamp(mContext, mSong.id);
 	}
 
 
 	private void storeTimestampdataForSong() {
-		if(mSong == null || mSong.id == 0 || mSong.albumId == 0 || c == null){
+		if(mSong == null || mSong.id == 0 || mSong.albumId == 0 || mContext == null){
 			return;
 		}
-		MediaLibrary.updateSongTimestamp(c, mSong.id, mTimestamp);
-		MediaLibrary.updateAlbumLastSong(c, mSong.id, mSong.albumId);
+		MediaLibrary.updateSongTimestamp(mContext, mSong.id, mTimestamp);
+		MediaLibrary.updateAlbumLastSong(mContext, mSong.id, mSong.albumId);
 	}
 
 

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
@@ -100,6 +100,9 @@ public class PlaybackTimestampHandler {
 
 	private void storeTimestampdataForSong() {
 		MediaLibrary.updateSongTimestamp(c, mSong.id, mTimestamp);
+		MediaLibrary.updateAlbumLastSong(c, mSong.id, mSong.albumId);
+
+
 	}
 
 

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/playback/PlaybackTimestampHandler.java
@@ -92,6 +92,9 @@ public class PlaybackTimestampHandler {
 	}
 
 	public int getInitialTimestamp() {
+		if(mSong==null){
+			return 0;
+		}
 		return MediaLibrary.getSongTimestamp(mContext, mSong.id);
 	}
 

--- a/app/src/main/res/drawable/ic_add_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_add_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#A0A6A5"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_clear_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_clear_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#A0A6A5"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/layout/seek_bar.xml
+++ b/app/src/main/res/layout/seek_bar.xml
@@ -28,10 +28,11 @@ THE SOFTWARE.
 	android:background="?overlay_background_color"
 	android:elevation="2dp"
 	android:orientation="horizontal">
+
 	<TextView
 		android:id="@+id/elapsed"
-		android:layout_height="wrap_content"
 		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
 		android:layout_gravity="center"
 		android:paddingLeft="5dip" />
 	<SeekBar

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="play_all_start_with_last_played">Play all / Start with last played</string>
+	<string name="storeAlbumTimestamp">storeAlbumTimestamp</string>
+	<string name="dontStoreAlbumTimestamp">dontStoreAlbumTimestamp</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="play_all_start_with_last_played">Play all / Start with last played</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-	<string name="play_all_start_with_last_played">Play all / Start with last played</string>
-	<string name="storeAlbumTimestamp">storeAlbumTimestamp</string>
-	<string name="dontStoreAlbumTimestamp">dontStoreAlbumTimestamp</string>
-</resources>

--- a/app/src/main/res/values/translatable.xml
+++ b/app/src/main/res/values/translatable.xml
@@ -416,9 +416,9 @@ THE SOFTWARE.
 
 
 	<!-- Timestamp storing -->
-	<string name="play_all_start_with_last_played">Play all / Start with last played</string>
-	<string name="storeAlbumTimestamp">Remember timestamp for songs</string>
-	<string name="dontStoreAlbumTimestamp">Dont remember timestamp for songs</string>
+	<string name="play_all_start_with_last_played">Continue album</string>
+	<string name="store_album_timestamp">Remember timestamp for songs</string>
+	<string name="dont_store_album_timestamp">Dont remember timestamp for songs</string>
 	<string name="remember_track_position_title">Remember Trackposition</string>
 	<string name="remember_track_position_summary">Continue the track at the last listened time for non selected albums</string>
 

--- a/app/src/main/res/values/translatable.xml
+++ b/app/src/main/res/values/translatable.xml
@@ -412,4 +412,14 @@ THE SOFTWARE.
 	<string name="theme_name_red_light">Red</string>
 	<string name="theme_name_red_dark">Red (Dark)</string>
 	<string name="theme_name_amoled_dark">Pitch Black (AMOLED)</string>
+
+
+
+	<!-- Timestamp storing -->
+	<string name="play_all_start_with_last_played">Play all / Start with last played</string>
+	<string name="storeAlbumTimestamp">Remember timestamp for songs</string>
+	<string name="dontStoreAlbumTimestamp">Dont remember timestamp for songs</string>
+	<string name="remember_track_position_title">Remember Trackposition</string>
+	<string name="remember_track_position_summary">Continue the track at the last listened time for non selected albums</string>
+
 </resources>

--- a/app/src/main/res/values/translatable.xml
+++ b/app/src/main/res/values/translatable.xml
@@ -417,9 +417,9 @@ THE SOFTWARE.
 
 	<!-- Timestamp storing -->
 	<string name="play_all_start_with_last_played">Continue album</string>
-	<string name="store_album_timestamp">Remember timestamp for songs</string>
-	<string name="dont_store_album_timestamp">Dont remember timestamp for songs</string>
-	<string name="remember_track_position_title">Remember Trackposition</string>
-	<string name="remember_track_position_summary">Continue the track at the last listened time for non selected albums</string>
+	<string name="store_album_timestamp">Remember last position</string>
+	<string name="dont_store_album_timestamp">Dont remember last position</string>
+	<string name="remember_track_position_title">Remember Last Position</string>
+	<string name="remember_track_position_summary">Continue the track at the last listened time for all albums</string>
 
 </resources>

--- a/app/src/main/res/xml/preference_playback.xml
+++ b/app/src/main/res/xml/preference_playback.xml
@@ -28,6 +28,11 @@ THE SOFTWARE.
 		android:title="@string/playback_on_startup_title"
 		android:summary="@string/playback_on_startup_summary"
 		android:defaultValue="false" />
+	<CheckBoxPreference
+		android:key="jump_to_last_position_of_track_state"
+		android:title="@string/remember_track_position_title"
+		android:summary="@string/remember_track_position_summary"
+		android:defaultValue="false" />
 	<ch.blinkenlights.android.vanilla.ListPreferenceSummary
 		android:key="display_mode"
 		android:title="@string/display_mode_title"


### PR DESCRIPTION
This pr adds the ability to store the last known time of a song in the database. Currently if the app restarts or crashes, it loads the last known timestamp for the song, and starts playing from there. Each song has its own timestamp and starts always at this timestamp.

Todo/discussion:

When should this media player start from the remembered position?
 - Mark each song as remember position type
 - Generally, but make it opt in
 - Based on id3 tags (mainly genere, podcast, audiobook etc.)

I tend to 1. but i think 3. could also be a good idea (maybe even a combination of all 3)


Also i want to implement that if you play a full album, it should play the last played song at the last remembered time (obeying the rules mentioned above)


closes #841


