### PR TITLE
Simplify plugin package search. Fix plugin detection.

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/FullPlaybackActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/FullPlaybackActivity.java
@@ -410,7 +410,7 @@ public class FullPlaybackActivity extends SlidingPlaybackActivity
 				if (song != null) {
 					Intent songIntent = new Intent();
 					songIntent.putExtra("id", song.id);
-					queryPluginsForIntent(songIntent);
+					showPluginMenu(songIntent);
 				}
 				break;
 		default:

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryActivity.java
@@ -771,7 +771,7 @@ public class LibraryActivity
 			TrackDetailsDialog.show(getFragmentManager(), songId);
 			break;
 		case CTX_MENU_PLUGINS: {
-			queryPluginsForIntent(intent);
+			showPluginMenu(intent);
 			break;
 		}
 		case CTX_MENU_MORE_FROM_ARTIST: {

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PluginUtils.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PluginUtils.java
@@ -18,11 +18,15 @@ package ch.blinkenlights.android.vanilla;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.widget.Toast;
+import androidx.annotation.NonNull;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Common plugin utilities and constants reside here.
@@ -52,9 +56,42 @@ public class PluginUtils {
 
     static final String EXTRA_PLUGIN_MAP = "ch.blinkenlights.android.vanilla.internal.extra.PLUGIN_MAP";
 
+	/**
+	 * Find all vanilla plugins by their very specific broadcast receiver intent.
+	 * @param ctx context to use when resolving packages.
+	 * @return list of all resolved plugins, may be empty but never null
+	 */
+	@NonNull
+	private static List<ResolveInfo> resolvePlugins(Context ctx) {
+		PackageManager pm = ctx.getPackageManager();
+		Intent filter = new Intent(ACTION_REQUEST_PLUGIN_PARAMS);
+		return pm.queryBroadcastReceivers(filter, PackageManager.GET_DISABLED_COMPONENTS);
+	}
+
+	/**
+	 * Checks whether does any of vanilla plugins exist on this Android system
+	 * @param ctx context to use when resolving packages
+	 * @return true if at least one plugin is installed, false otherwise
+	 */
     public static boolean checkPlugins(Context ctx) {
-        PackageManager pm = ctx.getPackageManager();
-        List<ResolveInfo> resolved = pm.queryBroadcastReceivers(new Intent(ACTION_REQUEST_PLUGIN_PARAMS), 0);
-        return !resolved.isEmpty();
+        return !resolvePlugins(ctx).isEmpty();
     }
+
+	/**
+	 * Same as {@link #resolvePlugins(Context)} but in a map convenient for showing in dialogs.
+	 * @param ctx ctx context to use when resolving packages
+	 * @return all vanilla plugins in a map App Name <-> App Info
+	 */
+	@NonNull
+	public static Map<String, ApplicationInfo> getPluginMap(Context ctx) {
+		PackageManager pm = ctx.getPackageManager();
+		List<ResolveInfo> resolved = resolvePlugins(ctx);
+
+		Map<String, ApplicationInfo> pluginMap = new HashMap<>(resolved.size());
+		for (ResolveInfo ri : resolved) {
+			ApplicationInfo appInfo = ri.activityInfo.applicationInfo;
+			pluginMap.put(appInfo.loadLabel(pm).toString(), appInfo);
+		}
+		return pluginMap;
+	}
 }


### PR DESCRIPTION
Currently plugin searching still works in two stages, first it searches
for all plugin broadcast receivers and then waits for all the answers
to complete the plugin map. If any of plugins doesn't answer the call
this means all of them won't be shown and that's not very user-friendly.

The change simplifies plugin search to just package scan for specific
broadcast receivers. Android provides package name and app info for it.
We don't need any other info from plugins, so we don't need to wait for
broadcast roadtrip.

Further improvements:
* introduce meta-data and uses-feature tags in
plugin manifests and get rid of broadcast receiver completely.
* Implement view in settings activity with list of installed plugins