### PR TITLE
Fix relative path resolution

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/FileUtils.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/FileUtils.java
@@ -20,6 +20,7 @@ package ch.blinkenlights.android.vanilla;
 import ch.blinkenlights.android.medialibrary.MediaLibrary;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URLConnection;
 import java.net.URISyntaxException;
@@ -142,10 +143,12 @@ public class FileUtils {
 
 		try {
 			if (!destination.isAbsolute()) {
-				path = new File(base, path).getAbsolutePath();
+				path = new File(base, path).getCanonicalPath();
 			}
 		} catch (SecurityException ex) {
 			// Ignore.
+		}catch (IOException ex){
+			// Ignore
 		}
 		return path;
 	}


### PR DESCRIPTION
When you have a music folder /music and a playlists folder /music/playlists , then reading a playlist with a song ../a.mp3 inside resolved to "/music/playlists/../a.mp3" , which broke the import operation. Using getCanonicalPath instead of getAbsolutePath fixes the issue, since the former resolves the URI to /music/a.mp3