### PR TITLE
Fixed back button behavior in Setting-Audio

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PreferencesActivity.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PreferencesActivity.java
@@ -25,9 +25,11 @@ package ch.blinkenlights.android.vanilla;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.FragmentManager;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.graphics.Color;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
@@ -166,7 +168,10 @@ public class PreferencesActivity extends PreferenceActivity
 				// ignored. Whee!
 			}
 
-			getActivity().finish();
+			FragmentManager fragmentManager = getFragmentManager();
+			if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || !fragmentManager.isStateSaved()) {
+				fragmentManager.popBackStack();
+			}
 		}
 	}
 
@@ -275,7 +280,7 @@ public class PreferencesActivity extends PreferenceActivity
 
 			if (intent != null) {
 				startActivity(intent);
-				activity.finish();
+				activity.onBackPressed();
 			} else {
 				// package is not installed, ask user to install it
 				new AlertDialog.Builder(activity)
@@ -286,12 +291,12 @@ public class PreferencesActivity extends PreferenceActivity
 						Intent marketIntent = new Intent(Intent.ACTION_VIEW);
 						marketIntent.setData(Uri.parse("market://details?id="+VPLUG_PACKAGE_NAME));
 						startActivity(marketIntent);
-						getActivity().finish();
+						getActivity().onBackPressed();
 					}
 				})
 				.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
 					public void onClick(DialogInterface dialog, int id) {
-						getActivity().finish();
+						getActivity().onBackPressed();
 					}
 				})
 				.show();


### PR DESCRIPTION
Previously, hitting back button after opening Equalizer or Play when plugged will exit the whole setting. Now back button will take us back to Audio.