### PR TITLE
Fix playlist path resolution for symlinked paths.

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/FileUtils.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/FileUtils.java
@@ -20,10 +20,11 @@ package ch.blinkenlights.android.vanilla;
 import ch.blinkenlights.android.medialibrary.MediaLibrary;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URLConnection;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
 
 import android.content.Context;
 import android.content.Intent;
@@ -31,6 +32,7 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
+import android.text.TextUtils;
 import android.util.Log;
 
 
@@ -144,12 +146,28 @@ public class FileUtils {
 
 		try {
 			if (!destination.isAbsolute()) {
-				path = new File(base, path).getCanonicalPath();
+				path = new File(base, path).getAbsolutePath();
+				final ArrayList<String> pathComponents = new ArrayList<>();
+				final StringTokenizer pathTokenizer = new StringTokenizer(path, File.separator);
+
+				while (pathTokenizer.hasMoreTokens()) {
+					final String pathComponent = pathTokenizer.nextToken();
+
+					if (NAME_PARENT_FOLDER.equals(pathComponent)) {
+						final int lastComponentPosition = pathComponents.size() - 1;
+
+						if (lastComponentPosition >= 0
+							&& !NAME_PARENT_FOLDER.equals(pathComponents.get(lastComponentPosition))) {
+							pathComponents.remove(lastComponentPosition);
+						}
+					} else {
+						pathComponents.add(pathComponent);
+					}
+				}
+				path = File.separator + TextUtils.join(File.separator, pathComponents);
 			}
 		} catch (SecurityException ex) {
 			// Ignore.
-		}catch (IOException ex){
-			// Ignore
 		}
 		return path;
 	}


### PR DESCRIPTION
When resolving relative paths such as `../../storage/emulated/0/` the symlinks will be read and parent paths removed, in that order. This results in paths from an `/sdcard` symlink producing unexpected relative paths e.g.`/sdcard/../storage/emulated/0/test.mp3` resolves to `/storage/emulated/storage/emulated/0/test.mp3` instead of `/storage/emulated/0/test.mp3`.
Because `relativize` does not canonicalize, this can also result in Vanilla producing paths it cannot reimport.

This change fixes path resolution to remove parent directories, without following symbolic links.

Some unscientific tests on my device indicate this also improves playlist import performance.

This should partially resolve issue #966. 