### PR TITLE
Fix / and /storage/emulated not showing any files

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/FolderPickerAdapter.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/FolderPickerAdapter.java
@@ -18,16 +18,11 @@
 package ch.blinkenlights.android.vanilla;
 
 import android.content.Context;
-import android.app.Activity;
 import android.os.Environment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.LayoutInflater;
 import android.widget.ArrayAdapter;
-import android.widget.TextView;
-import android.widget.ImageView;
-import android.graphics.drawable.Drawable;
 
 import java.io.File;
 import java.util.Arrays;
@@ -183,13 +178,26 @@ public class FolderPickerAdapter
 		if (!mFsRoot.equals(path))
 			add(new FolderPickerAdapter.Item("..", null, 0));
 
-		// Hack alert: Android >= 6.0's default storage root directory
-		// is usually not readable. That's not a big issue but
-		// can be very annoying for users who browse around.
-		// We are therefore detecting this and will 'simulate'
-		// the existence of the default storage root.
-		if (dirs == null && mStorageDir.getParentFile().equals(path)) {
-			dirs = new File[] { mStorageDir };
+		// Hack alert: On Android >. 6.0, some of the parent directories
+		// of the external storage may not be readable, meaning that if
+		// the user browses up the tree, they may suddenly not have the
+		// option to go back. Think of going from /storage/emulated/0 to
+		// /storage/emulated and not seeing the 0 option anymore.
+		if (dirs == null) {
+			File possibleChild = mStorageDir;
+			while (true) {
+				File possibleParent = possibleChild.getParentFile();
+				if (possibleParent == null) {
+					break;
+				}
+
+				if (possibleParent.equals(path)) {
+					dirs = new File[] { possibleChild };
+					break;
+				}
+
+				possibleChild = possibleChild.getParentFile();
+			}
 		}
 
 		if (dirs != null) {


### PR DESCRIPTION
I'm not a huge fan of the duplicated code, but I'm not sure how to better fix this. Before this fix /storage/emulated only works in the screen to select the filebrowser home though, so the duplicated code is still better than no code.

Before:
![photo_2020-05-29_20-48-16](https://user-images.githubusercontent.com/1885159/83294540-c0ab6300-a1ed-11ea-8e20-39ed4003ccc7.jpg)
![photo_2020-05-29_20-48-14](https://user-images.githubusercontent.com/1885159/83294544-c143f980-a1ed-11ea-94fd-47869dfbc468.jpg)
![photo_2020-05-29_20-48-12](https://user-images.githubusercontent.com/1885159/83294546-c1dc9000-a1ed-11ea-98aa-c6f899454572.jpg)

After:
![photo_2020-05-29_20-45-21](https://user-images.githubusercontent.com/1885159/83294265-54c8fa80-a1ed-11ea-9d1e-ae97ba46fd53.jpg)
![photo_2020-05-29_20-45-19](https://user-images.githubusercontent.com/1885159/83294269-55619100-a1ed-11ea-9bf4-15671233a31f.jpg)
![photo_2020-05-29_20-45-18](https://user-images.githubusercontent.com/1885159/83294272-55fa2780-a1ed-11ea-9789-60eaa6b84067.jpg)
