### PR TITLE
Fix genre tab expansion when tracks tab is no present

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryPagerAdapter.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/LibraryPagerAdapter.java
@@ -262,12 +262,21 @@ public class LibraryPagerAdapter
 	 */
 	public void computeExpansions()
 	{
-		if (mArtistAdapter != null)
-			mArtistAdapter.setExpandable(getMediaTypePosition(MediaUtils.TYPE_SONG) != -1 || getMediaTypePosition(MediaUtils.TYPE_ALBUM) != -1);
-		if (mAlbumAdapter != null)
-			mAlbumAdapter.setExpandable(getMediaTypePosition(MediaUtils.TYPE_SONG) != -1);
 		if (mGenreAdapter != null)
-			mGenreAdapter.setExpandable(getMediaTypePosition(MediaUtils.TYPE_SONG) != -1);
+			mGenreAdapter.setExpandable(
+				getMediaTypePosition(MediaUtils.TYPE_SONG) != -1 ||
+				getMediaTypePosition(MediaUtils.TYPE_ALBUM) != -1 ||
+				getMediaTypePosition(MediaUtils.TYPE_ARTIST) != -1
+			);
+		if (mArtistAdapter != null)
+			mArtistAdapter.setExpandable(
+				getMediaTypePosition(MediaUtils.TYPE_SONG) != -1 ||
+				getMediaTypePosition(MediaUtils.TYPE_ALBUM) != -1
+			);
+		if (mAlbumAdapter != null)
+			mAlbumAdapter.setExpandable(
+				getMediaTypePosition(MediaUtils.TYPE_SONG) != -1
+			);
 	}
 
 	@Override
@@ -314,7 +323,11 @@ public class LibraryPagerAdapter
 				break;
 			case MediaUtils.TYPE_GENRE:
 				adapter = mGenreAdapter = new MediaAdapter(activity, MediaUtils.TYPE_GENRE, null, activity);
-				mGenreAdapter.setExpandable(getMediaTypePosition(MediaUtils.TYPE_SONG) != -1);
+				mGenreAdapter.setExpandable(
+					getMediaTypePosition(MediaUtils.TYPE_SONG) != -1 ||
+					getMediaTypePosition(MediaUtils.TYPE_ALBUM) != -1 ||
+					getMediaTypePosition(MediaUtils.TYPE_ARTIST) != -1
+				);
 				break;
 			case MediaUtils.TYPE_FILE:
 				adapter = mFilesAdapter = new FileSystemAdapter(activity, mPendingFileLimiter);


### PR DESCRIPTION
When the tracks tab is available, the genre tab is correctly expanded following the expected sequence (genre -> artist -> album -> track). But if the tracks tab is disabled, then the genre is not expanded even if artist and/or album tabs are enabled. Instead, it adds all tracks for that genre to the playlist.

This is because the expansion for genre is currently based on detecting only the tracks tab, ignoring the presence of the artists and/or albums tabs. This PR adds these conditions so the genre is correctly expanded in this case.