### PR TITLE
Support adding all files from a directory

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/MediaUtils.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/MediaUtils.java
@@ -113,6 +113,12 @@ public class MediaUtils {
 	private static final String FILE_SORT = "path";
 
 	/**
+	 * The number of files that are added when "play all" selects
+	 * files from the file-system.
+	 */
+	private static final int MAX_QUEUED_FILES = 500;
+
+	/**
 	 * Cached random instance.
 	 */
 	private static Random sRandom;
@@ -603,6 +609,12 @@ public class MediaUtils {
 		Arrays.sort(files);
 
 		for (File file : files) {
+			// don't add more files endlessly, but stop after
+			// the given maximum number of entries
+			if (matrixCursor.getCount() >= MAX_QUEUED_FILES) {
+				break;
+			}
+
 			if (file.isDirectory()) {
 				// recurse into this sub-directory
 				addDirectoryToCursor(file, matrixCursor);

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/MediaUtils.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/MediaUtils.java
@@ -28,6 +28,7 @@ import ch.blinkenlights.android.medialibrary.MediaMetadataExtractor;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -538,12 +539,28 @@ public class MediaUtils {
 	}
 
 	/**
-	 * Returns a (possibly empty) Cursor for given file path
+	 * Returns a (possibly empty) Cursor for given file path.
+	 *
+	 * For directories, it recursively adds all files contained
+	 * in this directory.
+	 *
 	 * @param path The path to the file to be queried
 	 * @return A new Cursor object
 	 * */
 	public static Cursor getCursorForFileQuery(String path) {
 		MatrixCursor matrixCursor = new MatrixCursor(Song.FILLED_PROJECTION);
+
+		File directory = new File(path);
+		if (directory.isDirectory()) {
+			addDirectoryToCursor(directory, matrixCursor);
+		} else {
+			addFileToCursor(path, matrixCursor);
+		}
+
+		return matrixCursor;
+	}
+
+	private static void addFileToCursor(String path, MatrixCursor matrixCursor) {
 		MediaMetadataExtractor tags = new MediaMetadataExtractor(path);
 		String title = tags.getFirst(MediaMetadataExtractor.TITLE);
 		String album = tags.getFirst(MediaMetadataExtractor.ALBUM);
@@ -574,8 +591,25 @@ public class MediaUtils {
 
 			matrixCursor.addRow(objData);
 		}
+	}
 
-		return matrixCursor;
+	private static void addDirectoryToCursor(File directory, MatrixCursor matrixCursor) {
+		File[] files = directory.listFiles();
+		if (files == null) {
+			return;
+		}
+
+		// make sure items are returned in sorted order by the cursor
+		Arrays.sort(files);
+
+		for (File file : files) {
+			if (file.isDirectory()) {
+				// recurse into this sub-directory
+				addDirectoryToCursor(file, matrixCursor);
+			} else {
+				addFileToCursor(file.getAbsolutePath(), matrixCursor);
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
Currently when trying to add a directory of music-files to the queue via "Play all", 
it often happens that Vanilla Music reports "0 tracks added to the queue". 

When debugging, I found that this happens when the files are not contained 
in the music database yet.

Currently only single files are handled, but it is useful to also
do this for directories by recursively adding all contained files.