### PR TITLE
Show cover art of songs not in albums

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/CoverCache.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/CoverCache.java
@@ -114,7 +114,12 @@ public class CoverCache {
 	 * @return a bitmap or null if no artwork was found
 	 */
 	public Bitmap getCoverFromSong(Context ctx, Song song, int size) {
-		CoverKey key = new CoverCache.CoverKey(MediaUtils.TYPE_ALBUM, song.albumId, size);
+		CoverKey key;
+		if (MediaUtils.isSongInAlbum(song.flags))
+			key = new CoverCache.CoverKey(MediaUtils.TYPE_ALBUM, song.albumId, size);
+		else
+			key = new CoverCache.CoverKey(MediaUtils.TYPE_SONG, song.id, size);
+
 		Bitmap cover = getStoredCover(key);
 		if (cover == null) {
 			cover = sBitmapDiskCache.createBitmap(ctx, song, size*size);
@@ -411,63 +416,66 @@ public class CoverCache {
 				InputStream inputStream = null;
 				InputStream sampleInputStream = null; // same as inputStream but used for getSampleSize
 
-				if ((CoverCache.mCoverLoadMode & CoverCache.COVER_MODE_VANILLA) != 0) {
-					final File baseFile  = new File(song.path);  // File object of queried song
-					String bestMatchPath = null;                 // The best cover-path we found
-					int bestMatchIndex   = COVER_MATCHES.length; // The best cover-index/priority found
-					int loopCount        = 0;                    // Directory items loop counter
+				//If the song is not in an album, skip checking for art in albums
+				if (MediaUtils.isSongInAlbum(song.flags)) {
+					if ((CoverCache.mCoverLoadMode & CoverCache.COVER_MODE_VANILLA) != 0) {
+						final File baseFile  = new File(song.path);  // File object of queried song
+						String bestMatchPath = null;                 // The best cover-path we found
+						int bestMatchIndex   = COVER_MATCHES.length; // The best cover-index/priority found
+						int loopCount        = 0;                    // Directory items loop counter
 
-					// Only start search if the base directory of this file is NOT the public
-					// downloads folder: Picking files from there would lead to a false positive
-					// in most cases
-					if (baseFile.getParentFile().equals(sDownloadsDir) == false) {
-						for (final File entry : baseFile.getParentFile().listFiles()) {
-							for (int i=0; i < bestMatchIndex ; i++) {
-								// We are checking each file entry to see if it matches a known
-								// cover pattern. We abort on first hit as the Pattern array is sorted from good->meh
-								if (COVER_MATCHES[i].matcher(entry.toString()).matches()) {
-									bestMatchIndex = i;
-									bestMatchPath = entry.toString();
-									break;
+						// Only start search if the base directory of this file is NOT the public
+						// downloads folder: Picking files from there would lead to a false positive
+						// in most cases
+						if (baseFile.getParentFile().equals(sDownloadsDir) == false) {
+							for (final File entry : baseFile.getParentFile().listFiles()) {
+								for (int i=0; i < bestMatchIndex ; i++) {
+									// We are checking each file entry to see if it matches a known
+									// cover pattern. We abort on first hit as the Pattern array is sorted from good->meh
+									if (COVER_MATCHES[i].matcher(entry.toString()).matches()) {
+										bestMatchIndex = i;
+										bestMatchPath = entry.toString();
+										break;
+									}
 								}
+								// Stop loop if we found the best match or if we looped 150 times
+								if (loopCount++ > 150 || bestMatchIndex == 0)
+									break;
 							}
-							// Stop loop if we found the best match or if we looped 150 times
-							if (loopCount++ > 150 || bestMatchIndex == 0)
-								break;
+						}
+
+						if (bestMatchPath != null) {
+							final File guessedFile = new File(bestMatchPath);
+							if (guessedFile.exists() && !guessedFile.isDirectory()) {
+								inputStream = new FileInputStream(guessedFile);
+								sampleInputStream = new FileInputStream(guessedFile);
+							}
 						}
 					}
 
-					if (bestMatchPath != null) {
-						final File guessedFile = new File(bestMatchPath);
+					if (inputStream == null && (CoverCache.mCoverLoadMode & CoverCache.COVER_MODE_SHADOW) != 0) {
+						final String shadowBase = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC).getPath() + "/.vanilla";
+						final String shadowPath = shadowBase + "/" + (song.artist.replaceAll("/", "_"))+"/"+(song.album.replaceAll("/", "_"))+".jpg";
+
+						File guessedFile = new File(shadowPath);
 						if (guessedFile.exists() && !guessedFile.isDirectory()) {
 							inputStream = new FileInputStream(guessedFile);
 							sampleInputStream = new FileInputStream(guessedFile);
 						}
 					}
-				}
 
-				if (inputStream == null && (CoverCache.mCoverLoadMode & CoverCache.COVER_MODE_SHADOW) != 0) {
-					final String shadowBase = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC).getPath() + "/.vanilla";
-					final String shadowPath = shadowBase + "/" + (song.artist.replaceAll("/", "_"))+"/"+(song.album.replaceAll("/", "_"))+".jpg";
+					if (inputStream == null && (CoverCache.mCoverLoadMode & CoverCache.COVER_MODE_ANDROID) != 0) {
+						ContentResolver res = ctx.getContentResolver();
+						long[] androidIds = MediaUtils.getAndroidMediaIds(ctx, song);
+						long albumId = androidIds[1];
 
-					File guessedFile = new File(shadowPath);
-					if (guessedFile.exists() && !guessedFile.isDirectory()) {
-						inputStream = new FileInputStream(guessedFile);
-						sampleInputStream = new FileInputStream(guessedFile);
-					}
-				}
-
-				if (inputStream == null && (CoverCache.mCoverLoadMode & CoverCache.COVER_MODE_ANDROID) != 0) {
-					ContentResolver res = ctx.getContentResolver();
-					long[] androidIds = MediaUtils.getAndroidMediaIds(ctx, song);
-					long albumId = androidIds[1];
-
-					if (albumId != -1) {
-						// now we can query for the album art path if we found an album id
-						Uri uri =  Uri.parse("content://media/external/audio/albumart/"+albumId);
-						sampleInputStream = res.openInputStream(uri);
-						if (sampleInputStream != null) // cache misses are VERY expensive here, so we check if the first open worked
-							inputStream = res.openInputStream(uri);
+						if (albumId != -1) {
+							// now we can query for the album art path if we found an album id
+							Uri uri =  Uri.parse("content://media/external/audio/albumart/"+albumId);
+							sampleInputStream = res.openInputStream(uri);
+							if (sampleInputStream != null) // cache misses are VERY expensive here, so we check if the first open worked
+								inputStream = res.openInputStream(uri);
+						}
 					}
 				}
 

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/LazyCoverView.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/LazyCoverView.java
@@ -135,8 +135,8 @@ public class LazyCoverView extends ImageView
 				// This message was sent due to a cache miss, but the cover might got cached in the meantime
 				Bitmap bitmap = sBitmapLruCache.get(payload.key);
 				if (bitmap == null) {
-					if (payload.key.mediaType == MediaUtils.TYPE_ALBUM) {
-						// We only display real covers for queries using the album id as key
+					if (payload.key.mediaType == MediaUtils.TYPE_ALBUM || payload.key.mediaType == MediaUtils.TYPE_SONG) {
+						// We only display real covers for queries using the album or song id as key
 						Song song = MediaUtils.getSongByTypeId(mContext, payload.key.mediaType, payload.key.mediaId);
 						if (song != null) {
 							bitmap = song.getSmallCover(mContext);

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/MediaAdapter.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/MediaAdapter.java
@@ -215,9 +215,6 @@ public class MediaAdapter
 			                                    MediaLibrary.SongColumns.PATH+" %1$s",
 			                                    MediaLibrary.SongColumns.DURATION+" %1$s",
 			                                  };
-			// Songs covers are cached per-album
-			mCoverCacheType = MediaUtils.TYPE_ALBUM;
-			coverCacheKey = MediaStore.Audio.Albums.ALBUM_ID;
 			break;
 		case MediaUtils.TYPE_PLAYLIST:
 			mSource = MediaLibrary.VIEW_PLAYLISTS;

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/MediaUtils.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/MediaUtils.java
@@ -672,4 +672,12 @@ public class MediaUtils {
 				return TYPE_INVALID;
 		}
 	}
+
+	/**
+	 * Check if a song's FLAG_NO_ALBUM flag is set
+	 * @param songFlags the Song's flags
+	 */
+	public static boolean isSongInAlbum(int songFlags) {
+		return (songFlags & Song.FLAG_NO_ALBUM) == 0;
+	}
 }

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaylistAdapter.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaylistAdapter.java
@@ -49,6 +49,7 @@ public class PlaylistAdapter extends CursorAdapter implements Handler.Callback {
 		MediaLibrary.ContributorColumns.ARTIST,
 		MediaLibrary.SongColumns.ALBUM_ID,
 		MediaLibrary.SongColumns.DURATION,
+		MediaLibrary.SongColumns.FLAGS
 	};
 
 	private final Context mContext;
@@ -109,6 +110,7 @@ public class PlaylistAdapter extends CursorAdapter implements Handler.Callback {
 		final String title = cursor.getString(2);
 		final String album = cursor.getString(3);
 		final String artist = cursor.getString(4);
+		final int flags = cursor.getInt(7);
 
 		ViewHolder holder = new ViewHolder();
 		holder.title = title;
@@ -121,7 +123,11 @@ public class PlaylistAdapter extends CursorAdapter implements Handler.Callback {
 		dview.setDuration(cursor.getLong(6));
 
 		LazyCoverView cover = dview.getCoverView();
-		cover.setCover(MediaUtils.TYPE_ALBUM, cursor.getLong(5), null);
+
+		if ((flags & MediaLibrary.SONG_FLAG_NO_ALBUM) == 0)
+			cover.setCover(MediaUtils.TYPE_ALBUM, cursor.getLong(5), null);
+		else
+			cover.setCover(MediaUtils.TYPE_SONG, cursor.getLong(1), null);
 	}
 
 	/**

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/ShowQueueAdapter.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/ShowQueueAdapter.java
@@ -133,7 +133,10 @@ public class ShowQueueAdapter extends BaseAdapter {
 		if (song.isFilled()) {
 			row.setText(song.title, song.album+" · "+song.artist);
 			row.setDuration(song.duration);
-			row.getCoverView().setCover(MediaUtils.TYPE_ALBUM, song.albumId, null);
+			if (MediaUtils.isSongInAlbum(song.flags))
+				row.getCoverView().setCover(MediaUtils.TYPE_ALBUM, song.albumId, null);
+			else
+				row.getCoverView().setCover(MediaUtils.TYPE_SONG, song.id, null);
 		}
 
 		row.highlightRow(position == mHighlightRow);

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/Song.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/Song.java
@@ -44,9 +44,13 @@ public class Song implements Comparable<Song> {
 	 */
 	public static final int FLAG_NO_COVER = 0x2;
 	/**
+	 * Indicates that this song does not belong to an album.
+	 */
+	public static final int FLAG_NO_ALBUM = 0x4;
+	/**
 	 * The number of flags.
 	 */
-	public static final int FLAG_COUNT = 2;
+	public static final int FLAG_COUNT = 3;
 
 
 	public static final String[] EMPTY_PROJECTION = {
@@ -135,7 +139,7 @@ public class Song implements Comparable<Song> {
 	public int discNumber;
 
 	/**
-	 * Song flags. Currently {@link #FLAG_RANDOM} or {@link #FLAG_NO_COVER}.
+	 * Song flags. Currently {@link #FLAG_RANDOM}, {@link #FLAG_NO_COVER} or {@link #FLAG_NO_ALBUM}.
 	 */
 	public int flags;
 
@@ -198,7 +202,7 @@ public class Song implements Comparable<Song> {
 		if ((libraryFlags & MediaLibrary.SONG_FLAG_NO_ALBUM) != 0) {
 			// Note that we only set, never unset: the song may already
 			// have the flag set for other reasons.
-			flags |= FLAG_NO_COVER;
+			flags |= FLAG_NO_ALBUM;
 		}
 	}
 


### PR DESCRIPTION
When a song is not in an album, the app will not show cover art that's embedded in the file.
This PR adds a new flag to `Song` to determine if it is in an album. If it is, the app in other places will use the cover from the album it is in, thus caching and loading it only once. If it's not, it will use the Song's ID to cache the album art.

I spent a few hours on this before realizing that the `unique-cover` branch has existed since 2016, however it has not had any activity ever since. This PR also differs from that branch because that branch just changed made it so every song's art is cached.