### PR TITLE
Adjusted controls layout for taller displays

### DIFF
--- a/Makefile.internal
+++ b/Makefile.internal
@@ -1,4 +1,0 @@
-all: build
-
-build:
-	@echo "Noop"

--- a/Makefile.internal
+++ b/Makefile.internal
@@ -1,0 +1,4 @@
+all: build
+
+build:
+	@echo "Noop"

--- a/app/src/main/res/layout/full_playback.xml
+++ b/app/src/main/res/layout/full_playback.xml
@@ -42,6 +42,8 @@ THE SOFTWARE.
 				android:layout_height="wrap_content"
 				android:background="?overlay_background_color"
 				android:elevation="2dp"
+				android:layout_marginBottom="20dip"
+				android:paddingBottom="20dip"
 				android:orientation="vertical">
 					<include layout="@layout/seek_bar" />
 					<include layout="@layout/controls" android:id="@+id/queue_slider" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -7,9 +7,9 @@
 	<dimen name="cover_padding_with_pmark">10sp</dimen>
 	<dimen name="text_padding">14sp</dimen>
 	<dimen name="row_normal_height">56sp</dimen>
-	<dimen name="controls_padding">4dip</dimen>
+	<dimen name="controls_padding">12dip</dimen>
 	<!-- height of the full playback view controls -->
-	<dimen name="full_playback_controls_height">90dip</dimen>
+	<dimen name="full_playback_controls_height">120dip</dimen>
 	<dimen name="track_details_dialog_padding">8dp</dimen>
 	<dimen name="material_text_subhead">16sp</dimen>
 	<!-- height of 'full_playback_alt' text -->


### PR DESCRIPTION
 As phone displays adopt taller aspect ratios & get rid of thick bezels/chins, it becomes much more challenging to operate playback one-handed on the go without a painful finger stretching.
 
 This was not a problem for a very long time on my trusty but rusty Motorola G3; now I have switched to Motorola G52, where my thumb naturally lands on a seekbar.
 
 Below are some pictures just for comparison.

![image](https://user-images.githubusercontent.com/674257/209736314-efa4133f-51b6-44a7-8029-561462da6d6a.png)
_Current version_

![image](https://user-images.githubusercontent.com/674257/209736339-2664ef81-f495-4f50-a984-1ebb0b8e7d8a.png)
_Modified version. The playback controls bar is a little bit raised above navigation bar._

You might reasonably ask how do I use navigation bar then, and the answer would be: _I suffer. A lot. Or just use a capacitive stylus, but that requires both hands._

Please feel free to close this pull request if it does not meet any requirements.