### PR TITLE
Export PlaybackService

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -169,7 +169,7 @@ THE SOFTWARE.
 		</receiver>
 		<service android:name="PlaybackService"
 			 android:foregroundServiceType="mediaPlayback"
-			 android:exported="false">
+			 android:exported="true">
 			<intent-filter>
 				<action android:name="ch.blinkenlights.android.vanilla.action.PLAY" />
 				<action android:name="ch.blinkenlights.android.vanilla.action.PAUSE" />


### PR DESCRIPTION
Fixes https://github.com/vanilla-music/vanilla-headphone-detector/issues/20. Introduced in c3175f756d8726fd7dc6ecb26877c89ef7ac1080.
Not allowing the service to be exported leads to permission denied by headphone detector which in turn crashes as described in the issue linked above.
All credits go to @klaufir216 for explaining the bug, I just created the PR.