### PR TITLE
Another attempt to fix notification issues

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -1101,6 +1101,7 @@ public final class PlaybackService extends Service
 		}
 
 		updateWidgets();
+		updateNotification();
 
 		if (mReadaheadEnabled)
 			triggerReadAhead();


### PR DESCRIPTION
I was wondering why widgets were updating promptly while the notifications lagged behind. A few weeks of observation resulted in adding a `updateNotification()` call into broadcast emitting function right after updating widgets.

So far it seems to be giving a consistent result.

Fixes #1151 