### PR TITLE
Issue #977: Remember playback position upon closing

### DIFF
--- a/app/src/main/java/ch/blinkenlights/android/vanilla/MediaSessionTracker.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/MediaSessionTracker.java
@@ -131,6 +131,7 @@ public class MediaSessionTracker {
 				metadataBuilder.putLong(MediaMetadataCompat.METADATA_KEY_TRACK_NUMBER, service.getTimelinePosition() + 1);
 				metadataBuilder.putLong(MediaMetadataCompat.METADATA_KEY_NUM_TRACKS, service.getTimelineLength());
 			}
+			service.saveState(service.mMediaPlayer != null ? service.mMediaPlayer.getCurrentPosition() : 0);
 			mMediaSession.setMetadata(metadataBuilder.build());
 		}
 


### PR DESCRIPTION
This fixes the issue that playback positions are not remembered when manually closing the app.
