### PR TITLE
Feature/dequeue rest in queue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,10 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix ".debug"
+            versionNameSuffix "-debug"
+        }
         release {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             minifyEnabled true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@ THE SOFTWARE.
 
 		<provider
 			android:name="androidx.core.content.FileProvider"
-			android:authorities="ch.blinkenlights.android.vanilla.fileprovider"
+			android:authorities="${applicationId}.fileprovider"
 			android:exported="false"
 			android:grantUriPermissions="true">
 			<meta-data

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/PlaybackService.java
@@ -2395,4 +2395,12 @@ public final class PlaybackService extends Service
 		mTimeline.removeSongPosition(which);
 	}
 
+	/**
+	 * Removes every song after the given queue position.
+	 * @param pos last index to keep
+	 */
+	public void removeSongsAfter(int pos) {
+		mTimeline.removeSongsAfter(pos);
+	}
+
 }

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/ShowQueueFragment.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/ShowQueueFragment.java
@@ -96,6 +96,7 @@ public class ShowQueueFragment extends Fragment
 	private final static int CTX_MENU_ADD_TO_PLAYLIST = 106;
 	private final static int CTX_MENU_MOVE_TO_TOP     = 107;
 	private final static int CTX_MENU_MOVE_TO_BOTTOM  = 108;
+	private final static int CTX_MENU_DEQUEUE_REST    = 109;
 
 	/**
 	 * Called on long-click on a adapeter row
@@ -126,6 +127,8 @@ public class ShowQueueFragment extends Fragment
 		fm.addSpacer(0);
 		fm.add(CTX_MENU_SHOW_DETAILS, 0, R.drawable.menu_details, R.string.details).setIntent(intent);
 		fm.add(CTX_MENU_REMOVE, 90, R.drawable.menu_remove, R.string.remove).setIntent(intent);
+		fm.add(CTX_MENU_DEQUEUE_REST, 90, R.drawable.menu_remove, R.string.dequeue_rest).setIntent(intent);
+
 
 		fm.show(view, x, y);
 		return true;
@@ -172,6 +175,9 @@ public class ShowQueueFragment extends Fragment
 				break;
 			case CTX_MENU_MOVE_TO_BOTTOM:
 				service.moveSongPosition(pos, service.getTimelineLength() - 1);
+				break;
+			case CTX_MENU_DEQUEUE_REST:
+				service.removeSongsAfter(pos);
 				break;
 			default:
 				throw new IllegalArgumentException("Unhandled menu id received!");

--- a/app/src/main/java/ch/blinkenlights/android/vanilla/SongTimeline.java
+++ b/app/src/main/java/ch/blinkenlights/android/vanilla/SongTimeline.java
@@ -1040,6 +1040,24 @@ public final class SongTimeline {
 	}
 
 	/**
+	 * Removes all songs after the given position in one shot.
+	 * @param pos last index to keep; everything after is dropped
+	 */
+	public void removeSongsAfter(int pos) {
+		synchronized (this) {
+			if (pos + 1 >= mSongs.size())
+				return;
+			saveActiveSongs();
+			mSongs.subList(pos + 1, mSongs.size()).clear();
+			if (mCurrentPos > pos)
+				mCurrentPos = pos;
+			broadcastChangedSongs();
+		}
+		changed();
+	}
+
+
+	/**
 	 * Broadcasts that the timeline state has changed.
 	 */
 	private void changed()


### PR DESCRIPTION
# Changes
- Adds new menu named "Dequeue rest" to remove songs from queue which below the currently selected song.
- See the screen recording below:

https://github.com/user-attachments/assets/7b79d6b9-f2ac-4bb4-9130-a7a3a9c74d17


